### PR TITLE
Event bus to streamline process up

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,6 +37,7 @@ module.exports = {
     "valid-jsdoc": 0,
     "quotes": ["error", "double", { allowTemplateLiterals: true }],
     "no-unused-vars": "warn",
+    "new-cap": ["error", { "properties": false }],
 
     // Enforces rules from .prettierrc file.
     // These should be fixed automatically with formatting.

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -28,8 +28,8 @@ env:
     ${{ github.event_name == 'workflow_dispatch' &&
       github.event.inputs.deployment-type == 'live' &&
       'build/deno-deploy/live' || 'build/deno-deploy/dev' }}
-  IN_FILE: "src/http.ts"
-  OUT_FILE: "http.bundle.js"
+  IN_FILE: "src/server-deno.ts"
+  OUT_FILE: "index.bundle.js"
 
 jobs:
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 node_modules/
 worker/
 test/data/cache/
+blocklists__/
 
 package-lock.json
 

--- a/deno.Dockerfile
+++ b/deno.Dockerfile
@@ -28,7 +28,7 @@ RUN ls -Fla
 ENTRYPOINT ["/bin/deno"]
 
 # This is only used while building, on fly.io
-CMD ["run", "--allow-net", "--allow-env", "--allow-read", "src/http.ts"]
+CMD ["run", "--allow-net", "--allow-env", "--allow-read", "src/server-deno.ts"]
 
 # Run port process as a root privilege user. For say port 53
 # USER root

--- a/fly.toml
+++ b/fly.toml
@@ -45,8 +45,10 @@ script_checks = []
   port = 443
 
   [[services.tcp_checks]]
-  grace_period = "1s"
-  interval = "15s"
+  # account for delay due to blocklists download that
+  # happens on process startup: plugin.js:systemReady
+  grace_period = "15s"
+  interval = "30s"
   restart_limit = 6
   timeout = "2s"
 

--- a/fly.toml
+++ b/fly.toml
@@ -24,8 +24,8 @@ auto_rollback = true
 # Don't use `[processes]`, undocumented and causes problems with [auto]scaling.
 # Instead, use CMD in Dockerfile.
 # [processes]
-# app = "run --allow-net --allow-env --import-map=import_map.json http.ts"
-# app = "node server.js"
+# app = "run --allow-net --allow-env --import-map=import_map.json server-deno.ts"
+# app = "node server-node.js"
 
 # DNS over HTTP[S]
 [[services]]

--- a/fly.toml
+++ b/fly.toml
@@ -70,7 +70,9 @@ script_checks = []
   port = 853
 
   [[services.tcp_checks]]
-  grace_period = "1s"
-  interval = "15s"
+  # account for delay due to blocklists download that
+  # happens on process startup: plugin.js:systemReady
+  grace_period = "15s"
+  interval = "30s"
   restart_limit = 6
   timeout = "2s"

--- a/node.Dockerfile
+++ b/node.Dockerfile
@@ -22,4 +22,4 @@ RUN rm -f *Dockerfile .dockerignore
 
 RUN ls -Fla
 
-CMD ["node", "src/server.js"]
+CMD ["node", "src/server-node.js"]

--- a/src/basic/userOperation.js
+++ b/src/basic/userOperation.js
@@ -15,6 +15,7 @@ export class UserOperation {
     this.userConfigCache = new UserCache(1000);
     this.blocklistFilter = new BlocklistFilter();
   }
+
   /**
    * @param {*} param
    * @param {*} param.dnsResolverUrl
@@ -27,7 +28,7 @@ export class UserOperation {
   }
 
   loadUser(param) {
-    let response = {};
+    const response = {};
     response.isException = false;
     response.exceptionStack = "";
     response.exceptionFrom = "";
@@ -38,7 +39,7 @@ export class UserOperation {
       if (!param.isDnsMsg) {
         return response;
       }
-      let userBlocklistInfo = {};
+      const userBlocklistInfo = {};
       userBlocklistInfo.from = "Cache";
       let blocklistFlag = getBlocklistFlag(param.request.url);
       let currentUser = this.userConfigCache.get(blocklistFlag);
@@ -48,14 +49,14 @@ export class UserOperation {
         currentUser.flagVersion = 0;
         currentUser.userServiceListUint = false;
 
-        let response = this.blocklistFilter.unstamp(blocklistFlag);
+        const response = this.blocklistFilter.unstamp(blocklistFlag);
         currentUser.userBlocklistFlagUint = response.userBlocklistFlagUint;
         currentUser.flagVersion = response.flagVersion;
 
         if (!util.emptyString(currentUser.userBlocklistFlagUint)) {
           currentUser.userServiceListUint = dnsBlockUtil.flagIntersection(
             currentUser.userBlocklistFlagUint,
-            this.blocklistFilter.wildCardUint,
+            this.blocklistFilter.wildCardUint
           );
         } else {
           blocklistFlag = "";
@@ -80,6 +81,7 @@ export class UserOperation {
     return response;
   }
 }
+
 /**
  * Get the blocklist flag from `Request` URL
  * DNS over TLS flag from SNI should be rewritten to `url`'s pathname
@@ -88,12 +90,12 @@ export class UserOperation {
  */
 function getBlocklistFlag(url) {
   let blocklistFlag = "";
-  let reqUrl = new URL(url);
+  const reqUrl = new URL(url);
 
   // Check if pathname has `/dns-query`
-  let tmpsplit = reqUrl.pathname.split("/");
+  const tmpsplit = reqUrl.pathname.split("/");
   if (tmpsplit.length > 1) {
-    if (tmpsplit[1].toLowerCase() == "dns-query") {
+    if (tmpsplit[1].toLowerCase() === "dns-query") {
       blocklistFlag = tmpsplit[2] || "";
     } else {
       blocklistFlag = tmpsplit[1] || "";

--- a/src/blocklist-wrapper/blocklistFilter.js
+++ b/src/blocklist-wrapper/blocklistFilter.js
@@ -9,7 +9,7 @@
 import { Buffer } from "buffer";
 import { DomainNameCache } from "../cache-wrapper/cache-wrapper.js";
 import { customTagToFlag as _customTagToFlag } from "./radixTrie.js";
-import { base32, rbase32 } from "./b32.js";
+import { rbase32 } from "./b32.js";
 
 export class BlocklistFilter {
   constructor() {
@@ -18,30 +18,10 @@ export class BlocklistFilter {
     this.blocklistBasicConfig = null;
     this.blocklistFileTag = null;
     this.domainNameCache = null;
-    //following wildCard array is hardcoded to avoid the usage of blocklistFileTag download from s3
-    //the hard coded array contains the list of blocklist files mentioned at setWildcardlist()
-    //TODO is future version wildcard list should be downloaded from KV or from env
+    // TODO: wildcard list should be fetched from S3/KV
     this.wildCardUint = new Uint16Array([
-      64544,
-      18431,
-      8191,
-      65535,
-      64640,
-      1,
-      128,
-      16320,
+      64544, 18431, 8191, 65535, 64640, 1, 128, 16320,
     ]);
-    /*
-    this.wildCardLists = new Set();
-    setWildcardlist.call(this);
-    const str = _customTagToFlag(
-      this.wildCardLists,
-      this.blocklistFileTag,
-    );
-    this.wildCardUint = new Uint16Array(str.length);
-    for (let i = 0; i < this.wildCardUint.length; i++) {
-      this.wildCardUint[i] = str.charCodeAt(i);
-    }*/
   }
 
   loadFilter(t, ft, blocklistBasicConfig, blocklistFileTag) {
@@ -84,24 +64,23 @@ export class BlocklistFilter {
 
   getB64FlagFromTag(tagList, flagVersion) {
     try {
-      if (flagVersion == "0") {
+      if (flagVersion === "0") {
         return encodeURIComponent(
           Buffer.from(
-            _customTagToFlag(tagList, this.blocklistFileTag),
-          ).toString("base64"),
+            _customTagToFlag(tagList, this.blocklistFileTag)
+          ).toString("base64")
         );
-      } else if (flagVersion == "1") {
-        return "1:" +
+      } else if (flagVersion === "1") {
+        return (
+          "1:" +
           encodeURI(
             btoa(
-              encodeToBinary(
-                _customTagToFlag(
-                  tagList,
-                  this.blocklistFileTag,
-                ),
-              ),
-            ).replace(/\//g, "_").replace(/\+/g, "-"),
-          );
+              encodeToBinary(_customTagToFlag(tagList, this.blocklistFileTag))
+            )
+              .replace(/\//g, "_")
+              .replace(/\+/g, "-")
+          )
+        );
       }
     } catch (e) {
       throw e;
@@ -136,8 +115,8 @@ function toUint(flag) {
     const response = {};
     response.userBlocklistFlagUint = "";
     response.flagVersion = "0";
-    //added to check if UserFlag is empty for changing dns request flow
-    flag = (flag) ? flag.trim() : "";
+    // added to check if UserFlag is empty for changing dns request flow
+    flag = flag ? flag.trim() : "";
 
     if (flag.length <= 0) {
       return response;
@@ -145,16 +124,17 @@ function toUint(flag) {
 
     const isFlagB32 = isB32(flag);
     // "v:b64" or "v+b32" or "uriencoded(b64)", where v is uint version
-    let s = flag.split(isFlagB32 ? b32delim : b64delim);
+    const s = flag.split(isFlagB32 ? b32delim : b64delim);
     let convertor = (x) => ""; // empty convertor
     let f = ""; // stamp flag
     const v = version(s);
 
-    if (v == "0") { // version 0
+    if (v === "0") {
+      // version 0
       convertor = Base64ToUint;
       f = s[0];
-    } else if (v == "1") {
-      convertor = (isFlagB32) ? Base32ToUint_v1 : Base64ToUint_v1;
+    } else if (v === "1") {
+      convertor = isFlagB32 ? Base32ToUintV1 : Base64ToUintV1;
       f = s[1];
     } else {
       throw new Error("unknown blocklist stamp version in " + s);
@@ -179,7 +159,7 @@ function Base64ToUint(b64Flag) {
   return uint;
 }
 
-function Base64ToUint_v1(b64Flag) {
+function Base64ToUintV1(b64Flag) {
   let str = decodeURI(b64Flag);
   str = decodeFromBinary(atob(str.replace(/_/g, "/").replace(/-/g, "+")));
   const uint = [];
@@ -189,7 +169,7 @@ function Base64ToUint_v1(b64Flag) {
   return uint;
 }
 
-function Base32ToUint_v1(flag) {
+function Base32ToUintV1(flag) {
   let str = decodeURI(flag);
   str = decodeFromBinaryArray(rbase32(str));
   const uint = [];
@@ -211,65 +191,4 @@ function decodeFromBinary(b, u8) {
 function decodeFromBinaryArray(b) {
   const u8 = true;
   return decodeFromBinary(b, u8);
-}
-
-function setWildcardlist() {
-  this.wildCardLists.add("KBI"); // safe-search-not-supported
-  this.wildCardLists.add("YWG"); // nextdns dht-bootstrap-nodes
-  this.wildCardLists.add("SMQ"); // nextdns file-hosting
-  this.wildCardLists.add("AQX"); // nextdns proxies
-  this.wildCardLists.add("BTG"); // nextdns streaming audio
-  this.wildCardLists.add("GUN"); // nextdns streaming video
-  this.wildCardLists.add("KSH"); // nextdns torrent clients
-  this.wildCardLists.add("WAS"); // nextdns torrent trackers
-  this.wildCardLists.add("AZY"); // nextdns torrent websites
-  this.wildCardLists.add("GWB"); // nextdns usenet
-  this.wildCardLists.add("YMG"); // nextdns warez
-  this.wildCardLists.add("CZM"); // tiuxo porn
-  this.wildCardLists.add("ZVO"); // oblat social-networks
-  this.wildCardLists.add("YOM"); // 9gag srv
-  this.wildCardLists.add("THR"); // amazon srv
-  this.wildCardLists.add("RPW"); // blizzard srv
-  this.wildCardLists.add("AMG"); // dailymotion srv
-  this.wildCardLists.add("WTJ"); // discord srv
-  this.wildCardLists.add("ZXU"); // disney+ srv
-  this.wildCardLists.add("FJG"); // ebay srv
-  this.wildCardLists.add("NYS"); // facebook srv
-  this.wildCardLists.add("OKG"); // fortnite srv
-  this.wildCardLists.add("KNP"); // hulu srv
-  this.wildCardLists.add("FLI"); // imgur srv
-  this.wildCardLists.add("RYX"); // instagram srv
-  this.wildCardLists.add("CIH"); // leagueoflegends srv
-  this.wildCardLists.add("PTE"); // messenger srv
-  this.wildCardLists.add("KEA"); // minecraft srv
-  this.wildCardLists.add("CMR"); // netflix srv
-  this.wildCardLists.add("DDO"); // pinterest srv
-  this.wildCardLists.add("VLM"); // reddit srv
-  this.wildCardLists.add("JEH"); // roblox srv
-  this.wildCardLists.add("XLX"); // skype srv
-  this.wildCardLists.add("OQW"); // snapchat srv
-  this.wildCardLists.add("FXC"); // spotify srv
-  this.wildCardLists.add("HZJ"); // steam srv
-  this.wildCardLists.add("SWK"); // telegram srv
-  this.wildCardLists.add("VAM"); // tiktok srv
-  this.wildCardLists.add("AOS"); // tinder srv
-  this.wildCardLists.add("FAL"); // tumblr srv
-  this.wildCardLists.add("CZK"); // twitch srv
-  this.wildCardLists.add("FZB"); // twitter srv
-  this.wildCardLists.add("PYW"); // vimeo srv
-  this.wildCardLists.add("JXA"); // vk srv
-  this.wildCardLists.add("KOR"); // whatsapp srv
-  this.wildCardLists.add("DEP"); // youtube srv
-  this.wildCardLists.add("RFX"); // zoom srv
-  this.wildCardLists.add("RAF"); // parked-domains
-  this.wildCardLists.add("RKG"); // infosec.cert-pa.it
-  this.wildCardLists.add("GLV"); // covid malware sophos labs
-  this.wildCardLists.add("FHW"); // alexa native
-  this.wildCardLists.add("AGZ"); // apple native
-  this.wildCardLists.add("IVN"); // huawei native
-  this.wildCardLists.add("FIB"); // roku native
-  this.wildCardLists.add("FGF"); // samsung native
-  this.wildCardLists.add("FLL"); // sonos native
-  this.wildCardLists.add("IVO"); // windows native
-  this.wildCardLists.add("ALQ"); // xiaomi native
 }

--- a/src/command-control/cc.js
+++ b/src/command-control/cc.js
@@ -100,25 +100,25 @@ export class CommandControl {
         return response;
       }
 
-      let command = pathSplit[1];
+      const command = pathSplit[1];
       const b64UserFlag = this.userFlag(reqUrl, isDnsCmd);
 
-      if (command == "listtob64") {
+      if (command === "listtob64") {
         response.data.httpResponse = listToB64(queryString, blocklistFilter);
-      } else if (command == "b64tolist") {
+      } else if (command === "b64tolist") {
         response.data.httpResponse = b64ToList(queryString, blocklistFilter);
-      } else if (command == "dntolist") {
+      } else if (command === "dntolist") {
         response.data.httpResponse = domainNameToList(
           queryString,
           blocklistFilter,
           this.latestTimestamp
         );
-      } else if (command == "dntouint") {
+      } else if (command === "dntouint") {
         response.data.httpResponse = domainNameToUint(
           queryString,
           blocklistFilter
         );
-      } else if (command == "config" || command == "configure" || !isDnsCmd) {
+      } else if (command === "config" || command === "configure" || !isDnsCmd) {
         response.data.httpResponse = configRedirect(
           b64UserFlag,
           reqUrl.origin,
@@ -157,19 +157,19 @@ function configRedirect(userFlag, origin, timestamp, highlight) {
 }
 
 function domainNameToList(queryString, blocklistFilter, latestTimestamp) {
-  let domainName = queryString.get("dn") || "";
-  let returndata = {};
+  const domainName = queryString.get("dn") || "";
+  const returndata = {};
   returndata.domainName = domainName;
   returndata.version = latestTimestamp;
   returndata.list = {};
-  var searchResult = blocklistFilter.hadDomainName(domainName);
+  const searchResult = blocklistFilter.hadDomainName(domainName);
   if (searchResult) {
     let list;
     let listDetail = {};
-    for (let entry of searchResult) {
+    for (const entry of searchResult) {
       list = blocklistFilter.getTag(entry[1]);
       listDetail = {};
-      for (let listValue of list) {
+      for (const listValue of list) {
         listDetail[listValue] = blocklistFilter.blocklistFileTag[listValue];
       }
       returndata.list[entry[0]] = listDetail;
@@ -182,13 +182,13 @@ function domainNameToList(queryString, blocklistFilter, latestTimestamp) {
 }
 
 function domainNameToUint(queryString, blocklistFilter) {
-  let domainName = queryString.get("dn") || "";
-  let returndata = {};
+  const domainName = queryString.get("dn") || "";
+  const returndata = {};
   returndata.domainName = domainName;
   returndata.list = {};
-  var searchResult = blocklistFilter.hadDomainName(domainName);
+  const searchResult = blocklistFilter.hadDomainName(domainName);
   if (searchResult) {
-    for (let entry of searchResult) {
+    for (const entry of searchResult) {
       returndata.list[entry[0]] = entry[1];
     }
   } else {
@@ -199,9 +199,9 @@ function domainNameToUint(queryString, blocklistFilter) {
 }
 
 function listToB64(queryString, blocklistFilter) {
-  let list = queryString.get("list") || [];
-  let flagVersion = parseInt(queryString.get("flagversion")) || 0;
-  let returndata = {};
+  const list = queryString.get("list") || [];
+  const flagVersion = queryString.get("flagversion") || "0";
+  const returndata = {};
   returndata.command = "List To B64String";
   returndata.inputList = list;
   returndata.flagVersion = flagVersion;
@@ -213,15 +213,15 @@ function listToB64(queryString, blocklistFilter) {
 }
 
 function b64ToList(queryString, blocklistFilter) {
-  let b64 = queryString.get("b64") || "";
-  let returndata = {};
+  const b64 = queryString.get("b64") || "";
+  const returndata = {};
   returndata.command = "Base64 To List";
   returndata.inputB64 = b64;
-  let response = blocklistFilter.unstamp(b64);
+  const response = blocklistFilter.unstamp(b64);
   if (response.userBlocklistFlagUint.length > 0) {
     returndata.list = blocklistFilter.getTag(response.userBlocklistFlagUint);
     returndata.listDetail = {};
-    for (let listValue of returndata.list) {
+    for (const listValue of returndata.list) {
       returndata.listDetail[listValue] =
         blocklistFilter.blocklistFileTag[listValue];
     }

--- a/src/dns-operation/cacheResponse.js
+++ b/src/dns-operation/cacheResponse.js
@@ -7,6 +7,7 @@
  */
 
 import * as dnsutil from "../helpers/dnsutil.js";
+import * as cacheutil from "../helpers/cacheutil.js";
 
 export default class DNSCacheResponse {
   constructor() {}
@@ -44,7 +45,7 @@ export default class DNSCacheResponse {
   }
 
   async resolveFromCache(param) {
-    const key = dnsutil.cacheKey(param.requestDecodedDnsPacket);
+    const key = cacheutil.cacheKey(param.requestDecodedDnsPacket);
     if (!key) return false;
     const cacheResponse = await param.dnsCache.get(key, param.request.url);
     console.debug("cache key : ", key);
@@ -104,8 +105,8 @@ function generateResponse(cr, qid) {
   const response = {};
   response.dnsPacket = cr.dnsPacket;
 
-  dnsutil.updateQueryId(response.dnsPacket, qid);
-  dnsutil.updateTtl(response.dnsPacket, cr.metaData.ttlEndTime);
+  cacheutil.updateQueryId(response.dnsPacket, qid);
+  cacheutil.updateTtl(response.dnsPacket, cr.metaData.ttlEndTime);
 
   response.dnsBuffer = dnsutil.encode(response.dnsPacket);
 

--- a/src/dns-operation/cacheResponse.js
+++ b/src/dns-operation/cacheResponse.js
@@ -9,8 +9,8 @@
 import * as dnsutil from "../helpers/dnsutil.js";
 
 export default class DNSCacheResponse {
-  constructor() {
-  }
+  constructor() {}
+
   /**
    * @param {*} param
    * @param {*} param.userBlocklistInfo
@@ -23,7 +23,7 @@ export default class DNSCacheResponse {
    * @returns
    */
   async RethinkModule(param) {
-    let response = {};
+    const response = {};
     response.isException = false;
     response.exceptionStack = "";
     response.exceptionFrom = "";
@@ -46,7 +46,7 @@ export default class DNSCacheResponse {
   async resolveFromCache(param) {
     const key = dnsutil.cacheKey(param.requestDecodedDnsPacket);
     if (!key) return false;
-    let cacheResponse = await param.dnsCache.get(key, param.request.url);
+    const cacheResponse = await param.dnsCache.get(key, param.request.url);
     console.debug("cache key : ", key);
     console.debug("Cache Response", JSON.stringify(cacheResponse));
     if (!cacheResponse) return false;
@@ -55,37 +55,38 @@ export default class DNSCacheResponse {
       param.userBlocklistInfo,
       param.requestDecodedDnsPacket,
       param.dnsQuestionBlock,
-      param.dnsResponseBlock,
+      param.dnsResponseBlock
     );
   }
 }
+
 async function parseCacheResponse(cr, blockInfo, reqDnsPacket, qb, rb) {
-  //check dns-block for incoming request against blocklist metadata from cache
+  // check dns-block for incoming request against blocklist metadata from cache
   let response = checkDnsBlock(
     qb,
     reqDnsPacket,
     cr.metaData.cacheFilter,
-    blockInfo,
+    blockInfo
   );
-  console.debug("question block ",JSON.stringify(response))
+  console.debug("question block ", JSON.stringify(response));
   if (response && response.isBlocked) {
     return response;
   }
-  //cache response contains only metadata information
-  //return false to resolve dns request.
+  // cache response contains only metadata information
+  // return false to resolve dns request.
   if (!cr.metaData.bodyUsed) {
     return false;
   }
 
-  //answer block check
+  // answer block check
   response = checkDnsBlock(
     rb,
     cr.dnsPacket,
     cr.metaData.cacheFilter,
-    blockInfo,
+    blockInfo
   );
 
-  console.debug("answer block ",JSON.stringify(response))
+  console.debug("answer block ", JSON.stringify(response));
   if (response && response.isBlocked) {
     return response;
   }
@@ -100,7 +101,7 @@ function checkDnsBlock(qb, dnsPacket, cf, blockInfo) {
 }
 
 function generateResponse(cr, qid) {
-  let response = {};
+  const response = {};
   response.dnsPacket = cr.dnsPacket;
 
   dnsutil.updateQueryId(response.dnsPacket, qid);

--- a/src/dns-operation/dnsBlock.js
+++ b/src/dns-operation/dnsBlock.js
@@ -77,7 +77,7 @@ export default class DNSQuestionBlock {
 }
 
 function putCache(cache, url, blf, dnsPacket, buf, event) {
-  const key = dnsutil.cacheKey(dnsPacket);
+  const key = dnsCacheutil.cacheKey(dnsPacket);
   if (!key) return;
   const input = dnsCacheUtil.createCacheInput(dnsPacket, blf, false);
   cache.put(key, input, url, buf, event);

--- a/src/dns-operation/dnsBlock.js
+++ b/src/dns-operation/dnsBlock.js
@@ -6,12 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 import * as dnsutil from "../helpers/dnsutil.js";
-import * as dnsCacheUtil from "../helpers/cacheutil.js"
-import * as dnsBlockUtil from "../helpers/dnsblockutil.js"
+import * as dnsCacheUtil from "../helpers/cacheutil.js";
+import * as dnsBlockUtil from "../helpers/dnsblockutil.js";
 
 export default class DNSQuestionBlock {
-  constructor() {
-  }
+  constructor() {}
+
   /**
    * @param {*} param
    * @param {*} param.userBlocklistInfo
@@ -23,7 +23,7 @@ export default class DNSQuestionBlock {
    * @returns
    */
   async RethinkModule(param) {
-    let response = {};
+    const response = {};
     response.isException = false;
     response.exceptionStack = "";
     response.exceptionFrom = "";
@@ -41,11 +41,11 @@ export default class DNSQuestionBlock {
   }
 
   dnsBlock(param) {
-    let response = this.performBlocking(
+    const response = this.performBlocking(
       param.userBlocklistInfo,
       param.requestDecodedDnsPacket,
       param.blocklistFilter,
-      false,      
+      false
     );
     if (response && response.isBlocked) {
       console.debug("add block response to cache");
@@ -55,7 +55,7 @@ export default class DNSQuestionBlock {
         param.blocklistFilter,
         param.requestDecodedDnsPacket,
         "",
-        param.event,
+        param.event
       );
     }
     return response;
@@ -63,14 +63,15 @@ export default class DNSQuestionBlock {
 
   performBlocking(blockInfo, dnsPacket, blf, cf) {
     if (
-      !blockInfo.userBlocklistFlagUint || blockInfo.userBlocklistFlagUint === "" ||
+      !blockInfo.userBlocklistFlagUint ||
+      blockInfo.userBlocklistFlagUint === "" ||
       !dnsutil.isBlockable(dnsPacket)
     ) {
       return false;
     }
 
-    const qn = dnsutil.getQueryName(dnsPacket.questions)
-    if(!qn) return false;
+    const qn = dnsutil.getQueryName(dnsPacket.questions);
+    if (!qn) return false;
     return dnsBlockUtil.doBlock(blf, blockInfo, qn, cf);
   }
 }
@@ -78,6 +79,6 @@ export default class DNSQuestionBlock {
 function putCache(cache, url, blf, dnsPacket, buf, event) {
   const key = dnsutil.cacheKey(dnsPacket);
   if (!key) return;
-  let input = dnsCacheUtil.createCacheInput(dnsPacket, blf, false);
+  const input = dnsCacheUtil.createCacheInput(dnsPacket, blf, false);
   cache.put(key, input, url, buf, event);
 }

--- a/src/dns-operation/dnsBlock.js
+++ b/src/dns-operation/dnsBlock.js
@@ -77,7 +77,7 @@ export default class DNSQuestionBlock {
 }
 
 function putCache(cache, url, blf, dnsPacket, buf, event) {
-  const key = dnsCacheutil.cacheKey(dnsPacket);
+  const key = dnsCacheUtil.cacheKey(dnsPacket);
   if (!key) return;
   const input = dnsCacheUtil.createCacheInput(dnsPacket, blf, false);
   cache.put(key, input, url, buf, event);

--- a/src/dns-operation/dnsOperation.js
+++ b/src/dns-operation/dnsOperation.js
@@ -10,5 +10,12 @@ import DNSParserWrap from "./dnsParserWrap.js";
 import DNSQuestionBlock from "./dnsBlock.js";
 import DNSResponseBlock from "./dnsResponseBlock.js";
 import DNSResolver from "./dnsResolver.js";
-import DNSCacheResponse from "./cacheResponse.js"
-export { DNSQuestionBlock, DNSParserWrap, DNSResolver, DNSResponseBlock, DNSCacheResponse };
+import DNSCacheResponse from "./cacheResponse.js";
+
+export {
+  DNSQuestionBlock,
+  DNSParserWrap,
+  DNSResolver,
+  DNSResponseBlock,
+  DNSCacheResponse,
+};

--- a/src/dns-operation/dnsParserWrap.js
+++ b/src/dns-operation/dnsParserWrap.js
@@ -19,6 +19,7 @@ export default class DNSParserWrap {
       throw e;
     }
   }
+
   encode(DecodedDnsPacket) {
     try {
       return DnsParser.encode(DecodedDnsPacket);

--- a/src/dns-operation/dnsResolver.js
+++ b/src/dns-operation/dnsResolver.js
@@ -11,7 +11,7 @@ import * as dnsutil from "../helpers/dnsutil.js";
 import * as util from "../helpers/util.js";
 import * as envutil from "../helpers/envutil.js";
 import { DNSParserWrap as Dns } from "../dns-operation/dnsOperation.js";
-const quad1 = "1.1.1.2";
+
 export default class DNSResolver {
   constructor() {
     this.http2 = null;
@@ -21,24 +21,17 @@ export default class DNSResolver {
   }
 
   async lazyInit() {
-    if (!this.dnsResCache) {
-      this.dnsResCache = new LocalCache("dns-response-cache", dnsCacheSize);
-      log.i("create dnscache", dnsCacheSize);
-    }
-    if (envutil.isWorkers() && !this.httpCache) {
-      this.httpCache = caches.default;
-      log.i("init http-cache");
-    }
     if (envutil.isNode() && !this.http2) {
       this.http2 = await import("http2");
       this.nodeUtil = await import("../helpers/node/util.js");
       log.i("create custom http2 client");
     }
     if (envutil.isNode() && !this.transport) {
+      const plainOldDnsIp = dnsutil.dnsIpv4();
       this.transport = new (
         await import("../helpers/node/dns-transport.js")
-      ).Transport(quad1, 53);
-      log.i("create udp/tcp transport", quad1);
+      ).Transport(plainOldDnsIp, 53);
+      log.i("create udp/tcp transport", plainOldDnsIp);
     }
   }
 
@@ -70,7 +63,7 @@ export default class DNSResolver {
     const upRes = await this.resolveDnsUpstream(
       param.request,
       param.dnsResolverUrl,
-      param.requestBodyBuffer,
+      param.requestBodyBuffer
     );
     resp = await decodeResponse(upRes, this.dnsParser);
     return resp;
@@ -85,17 +78,15 @@ async function decodeResponse(response, dnsParser) {
     log.d("!OK", response.status, response.statusText, await response.text());
     throw new Error(response.status + " http err: " + response.statusText);
   }
-  let data = {};
+  const data = {};
   data.dnsBuffer = await response.arrayBuffer();
 
   if (!dnsutil.validResponseSize(data.dnsBuffer)) {
     throw new Error("Null / invalid response from upstream");
   }
   try {
-    //Todo: call dnsutil.encode makes answer[0].ttl as some big number need to debug.
-    data.dnsPacket = dnsParser.decode(
-      data.dnsBuffer,
-    );
+    // TODO: at times, dnsutil.encode sets answer[0].ttl to some large number
+    data.dnsPacket = dnsParser.decode(data.dnsBuffer);
   } catch (e) {
     log.e("decode fail " + response.status + " cache? " + data.dnsBuffer);
     throw e;
@@ -112,7 +103,7 @@ async function decodeResponse(response, dnsParser) {
 DNSResolver.prototype.resolveDnsUpstream = async function (
   request,
   resolverUrl,
-  requestBodyBuffer,
+  requestBodyBuffer
 ) {
   try {
     // for now, upstream plain-old dns on fly
@@ -130,9 +121,9 @@ DNSResolver.prototype.resolveDnsUpstream = async function (
         : new Response(null, { status: 503 });
     }
 
-    let u = new URL(request.url);
-    let dnsResolverUrl = new URL(resolverUrl);
-    u.hostname = dnsResolverUrl.hostname; // override host, default cloudflare-dns.com
+    const u = new URL(request.url);
+    const dnsResolverUrl = new URL(resolverUrl);
+    u.hostname = dnsResolverUrl.hostname; // default cloudflare-dns.com
     u.pathname = dnsResolverUrl.pathname; // override path, default /dns-query
     u.port = dnsResolverUrl.port; // override port, default 443
     u.protocol = dnsResolverUrl.protocol; // override proto, default https

--- a/src/dns-operation/dnsResponseBlock.js
+++ b/src/dns-operation/dnsResponseBlock.js
@@ -88,7 +88,7 @@ function doCnameBlock(dnsPacket, blf, blockInfo, cf) {
 
 function putCache(cache, url, blf, dnsPacket, buf, event) {
   if (!dnsCacheUtil.isCacheable(dnsPacket)) return;
-  const key = dnsutil.cacheKey(dnsPacket);
+  const key = dnsCacheUtil.cacheKey(dnsPacket);
   if (!key) return;
   const input = dnsCacheUtil.createCacheInput(dnsPacket, blf, true);
   console.debug("Cache Input ", JSON.stringify(input));

--- a/src/dns-operation/dnsResponseBlock.js
+++ b/src/dns-operation/dnsResponseBlock.js
@@ -10,8 +10,7 @@ import * as dnsCacheUtil from "../helpers/cacheutil.js";
 import * as dnsBlockUtil from "../helpers/dnsblockutil.js";
 
 export default class DNSResponseBlock {
-  constructor() {
-  }
+  constructor() {}
 
   /**
    * @param {*} param
@@ -25,7 +24,7 @@ export default class DNSResponseBlock {
    * @returns
    */
   async RethinkModule(param) {
-    let response = {};
+    const response = {};
     response.isException = false;
     response.exceptionStack = "";
     response.exceptionFrom = "";
@@ -35,7 +34,7 @@ export default class DNSResponseBlock {
         param.userBlocklistInfo,
         param.responseDecodedDnsPacket,
         param.blocklistFilter,
-        false,
+        false
       );
 
       putCache(
@@ -44,7 +43,7 @@ export default class DNSResponseBlock {
         param.blocklistFilter,
         param.responseDecodedDnsPacket,
         param.responseBodyBuffer,
-        param.event,
+        param.event
       );
     } catch (e) {
       response.isException = true;
@@ -57,33 +56,30 @@ export default class DNSResponseBlock {
   }
 
   performBlocking(blockInfo, dnsPacket, blf, cf) {
-    if (
-      !blockInfo.userBlocklistFlagUint || blockInfo.userBlocklistFlagUint === ""
-    ) {
+    if (!hasBlockstamp(blockInfo)) {
       return false;
-    }
-    if (dnsutil.isCname(dnsPacket)) {
+    } else if (dnsutil.isCname(dnsPacket)) {
       return doCnameBlock(dnsPacket, blf, blockInfo, cf);
-    }
-    if (dnsutil.isHttps(dnsPacket)) {
+    } else if (dnsutil.isHttps(dnsPacket)) {
       return doHttpsBlock(dnsPacket, blf, blockInfo, cf);
     }
+
     return false;
   }
 }
 
 function doHttpsBlock(dnsPacket, blf, blockInfo, cf) {
   console.debug("At Https-Svcb dns Block");
-  let tn = dnsutil.getTargetName(dnsPacket.answers);
+  const tn = dnsutil.getTargetName(dnsPacket.answers);
   if (!tn) return false;
   return dnsBlockUtil.doBlock(blf, blockInfo, tn, cf);
 }
 
 function doCnameBlock(dnsPacket, blf, blockInfo, cf) {
   console.debug("At Cname dns Block");
-  let cn = dnsutil.getCname(dnsPacket.answers);
+  const cn = dnsutil.getCname(dnsPacket.answers);
   let response = false;
-  for (let n of cn) {
+  for (const n of cn) {
     response = dnsBlockUtil.doBlock(blf, blockInfo, n, cf);
     if (response.isBlocked) break;
   }
@@ -94,7 +90,13 @@ function putCache(cache, url, blf, dnsPacket, buf, event) {
   if (!dnsCacheUtil.isCacheable(dnsPacket)) return;
   const key = dnsutil.cacheKey(dnsPacket);
   if (!key) return;
-  let input = dnsCacheUtil.createCacheInput(dnsPacket, blf, true);
+  const input = dnsCacheUtil.createCacheInput(dnsPacket, blf, true);
   console.debug("Cache Input ", JSON.stringify(input));
   cache.put(key, input, url, buf, event);
+}
+
+function hasBlockstamp(blockInfo) {
+  return (
+    blockInfo.userBlocklistFlagUint && blockInfo.userBlocklistFlagUint !== ""
+  );
 }

--- a/src/helpers/deno/config.ts
+++ b/src/helpers/deno/config.ts
@@ -1,10 +1,29 @@
 import { config as dotEnvConfig } from "dotenv";
+import * as system from "../../system.js";
+import Log from "../log.js";
 
-// Load env variables from .env file to Deno.env (if file exists)
-try {
-  dotEnvConfig({ export: true });
-  Deno.env.set("RUNTIME", "deno");
-} catch (e) {
-  // throws without --allow-read flag
-  console.warn(".env file may not be loaded => ", e.name, ":", e.message);
-}
+(main => {
+  if (!Deno) throw new Error("failed loading deno-specific config");
+
+  const isProd = Deno.env.get("DENO_ENV") === "production";
+
+  // Load env variables from .env file to Deno.env (if file exists)
+  try {
+    dotEnvConfig({ export: true });
+    // override: if we are running this file, then we're on Deno
+    Deno.env.set("RUNTIME", "deno");
+  } catch (e) {
+    // throws without --allow-read flag
+    console.warn(".env file may not be loaded => ", e.name, ":", e.message);
+  }
+
+  globalThis.envManager = new EnvManager();
+
+  globalThis.log = new Log(
+    env.logLevel,
+    isProd // set console level only in prod.
+  );
+
+  system.pub("ready");
+}();
+

--- a/src/helpers/deno/config.ts
+++ b/src/helpers/deno/config.ts
@@ -3,6 +3,14 @@ import * as system from "../../system.js";
 import Log from "../log.js";
 import EnvManager from "../env.js";
 
+declare global {
+  interface Window {
+    envManager?: EnvManager;
+    log?: Log;
+    env?: any;
+  }
+}
+
 ((main) => {
   if (!Deno) throw new Error("failed loading deno-specific config");
 
@@ -18,10 +26,10 @@ import EnvManager from "../env.js";
     console.warn(".env file may not be loaded => ", e.name, ":", e.message);
   }
 
-  globalThis.envManager = new EnvManager();
+  window.envManager = new EnvManager();
 
-  globalThis.log = new Log(
-    env.logLevel,
+  window.log = new Log(
+    window.env.logLevel,
     isProd, // set console level only in prod.
   );
 

--- a/src/helpers/deno/config.ts
+++ b/src/helpers/deno/config.ts
@@ -3,7 +3,11 @@ import * as system from "../../system.js";
 import Log from "../log.js";
 import EnvManager from "../env.js";
 
+// In global scope.
 declare global {
+  // TypeScript compiler needs to know type of every variable / property.
+  // So, we extend the window object (globalThis) with declaration merging.
+  // See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html
   interface Window {
     envManager?: EnvManager;
     log?: Log;

--- a/src/helpers/deno/config.ts
+++ b/src/helpers/deno/config.ts
@@ -1,8 +1,9 @@
 import { config as dotEnvConfig } from "dotenv";
 import * as system from "../../system.js";
 import Log from "../log.js";
+import EnvManager from "../env.js";
 
-(main => {
+((main) => {
   if (!Deno) throw new Error("failed loading deno-specific config");
 
   const isProd = Deno.env.get("DENO_ENV") === "production";
@@ -21,9 +22,8 @@ import Log from "../log.js";
 
   globalThis.log = new Log(
     env.logLevel,
-    isProd // set console level only in prod.
+    isProd, // set console level only in prod.
   );
 
   system.pub("ready");
-}();
-
+})();

--- a/src/helpers/dnsblockutil.js
+++ b/src/helpers/dnsblockutil.js
@@ -7,34 +7,34 @@
  */
 import * as util from "../helpers/util.js";
 
-export function isBlocklistFiter(blf) {
-  return (blf && blf.t && blf.ft)
+export function isBlocklistFilterSetup(blf) {
+  return blf && blf.t && blf.ft;
 }
 
 export function doBlock(blf, userBlInfo, key, cf) {
-  let blInfo = getDomainInfo(blf, cf, key);
-  console.debug("blocklist filter result : ",JSON.stringify(blInfo))
+  const blInfo = getDomainInfo(blf, cf, key);
+  console.debug("blocklist filter result : ", JSON.stringify(blInfo));
   if (!blInfo) return false;
-  let response = checkDomainBlocking(
+  const response = checkDomainBlocking(
     userBlInfo.userBlocklistFlagUint,
     userBlInfo.flagVersion,
     blInfo,
-    key,
+    key
   );
   if (response && response.isBlocked) return response;
 
-  if(!userBlInfo.userServiceListUint) return response;
+  if (!userBlInfo.userServiceListUint) return response;
 
   return checkWildcardBlocking(
     userBlInfo.userServiceListUint,
     userBlInfo.flagVersion,
     blInfo,
-    key,
+    key
   );
 }
 
 function getDomainInfo(blf, cf, key) {
-  if (isBlocklistFiter(blf)) {
+  if (isBlocklistFilterSetup(blf)) {
     return blf.getDomainInfo(key).searchResult;
   }
   if (!cf && !cf.hasOwnProperty(key)) return false;
@@ -43,7 +43,7 @@ function getDomainInfo(blf, cf, key) {
 
 function checkDomainBlocking(ufUint, flagVersion, blocklistMap, dn) {
   try {
-    let dnUint = blocklistMap.get(dn);
+    const dnUint = blocklistMap.get(dn);
     if (!dnUint) return false;
     return checkFlagIntersection(ufUint, dnUint, flagVersion, blocklistMap, dn);
   } catch (e) {
@@ -52,11 +52,11 @@ function checkDomainBlocking(ufUint, flagVersion, blocklistMap, dn) {
 }
 
 function checkWildcardBlocking(wcUint, flagVersion, blocklistMap, dn) {
-  let dnSplit = dn.split(".");
+  const dnSplit = dn.split(".");
   let dnJoin = "";
   let response = {};
   let dnUint;
-  while (dnSplit.shift() != undefined) {
+  while (dnSplit.shift() !== undefined) {
     dnJoin = dnSplit.join(".");
     dnUint = blocklistMap.get(dn);
     if (!dnUint) return false;
@@ -65,7 +65,7 @@ function checkWildcardBlocking(wcUint, flagVersion, blocklistMap, dn) {
       dnUint,
       flagVersion,
       blocklistMap,
-      dnJoin,
+      dnJoin
     );
     if (response && response.isBlocked) {
       return response;
@@ -76,54 +76,49 @@ function checkWildcardBlocking(wcUint, flagVersion, blocklistMap, dn) {
 
 function checkFlagIntersection(uint1, uint2, flagVersion, blocklistMap, key) {
   try {
-    let response = {};
+    const response = {};
     response.isBlocked = false;
     response.blockedB64Flag = "";
     response.blockedTag = [];
-    let dnUint = blocklistMap.get(key);
+    const dnUint = blocklistMap.get(key);
     let blockedUint = flagIntersection(uint1, uint2);
     if (blockedUint) {
       response.isBlocked = true;
-      response.blockedB64Flag = getB64Flag(
-        blockedUint,
-        flagVersion,
-      );
+      response.blockedB64Flag = getB64Flag(blockedUint, flagVersion);
     } else {
       blockedUint = new Uint16Array(dnUint);
-      response.blockedB64Flag = getB64Flag(
-        blockedUint,
-        flagVersion,
-      );
+      response.blockedB64Flag = getB64Flag(blockedUint, flagVersion);
     }
-    return response;    
-    //response.blockedTag = blocklistFilter.getTag(blockedUint);
+    return response;
+    // response.blockedTag = blocklistFilter.getTag(blockedUint);
   } catch (e) {
     throw e;
   }
 }
 
-export function flagIntersection(flag1, flag2) {  
+export function flagIntersection(flag1, flag2) {
   try {
     if (util.emptyString(flag1) || util.emptyString(flag2)) return false;
+
     let flag1Header = flag1[0];
     let flag2Header = flag2[0];
     let intersectHeader = flag1Header & flag2Header;
-    if (intersectHeader == 0) {
-      //console.log("first return")
+
+    if (intersectHeader === 0) {
       return false;
     }
+
     let flag1Length = flag1.length - 1;
     let flag2Length = flag2.length - 1;
     const intersectBody = [];
     let tmpInterectHeader = intersectHeader;
     let maskHeaderForBodyEmpty = 1;
     let tmpBodyIntersect;
-    for (; tmpInterectHeader != 0;) {
-      if ((flag1Header & 1) == 1) {
-        if ((tmpInterectHeader & 1) == 1) {
+    for (; tmpInterectHeader !== 0; ) {
+      if ((flag1Header & 1) === 1) {
+        if ((tmpInterectHeader & 1) === 1) {
           tmpBodyIntersect = flag1[flag1Length] & flag2[flag2Length];
-          //console.log(flag1[flag1Length] + " :&: " + flag2[flag2Length] + " -- " + tmpBodyIntersect)
-          if (tmpBodyIntersect == 0) {
+          if (tmpBodyIntersect === 0) {
             intersectHeader = intersectHeader ^ maskHeaderForBodyEmpty;
           } else {
             intersectBody.push(tmpBodyIntersect);
@@ -131,7 +126,7 @@ export function flagIntersection(flag1, flag2) {
         }
         flag1Length = flag1Length - 1;
       }
-      if ((flag2Header & 1) == 1) {
+      if ((flag2Header & 1) === 1) {
         flag2Length = flag2Length - 1;
       }
       flag1Header = flag1Header >>> 1;
@@ -139,16 +134,16 @@ export function flagIntersection(flag1, flag2) {
       flag2Header = flag2Header >>> 1;
       maskHeaderForBodyEmpty = maskHeaderForBodyEmpty * 2;
     }
-    //console.log(intersectBody)
-    if (intersectHeader == 0) {
-      //console.log("Second Return")
+
+    if (intersectHeader === 0) {
       return false;
     }
+
     const intersectFlag = new Uint16Array(intersectBody.length + 1);
     let count = 0;
     intersectFlag[count++] = intersectHeader;
     let bodyData;
-    while ((bodyData = intersectBody.pop()) != undefined) {
+    while ((bodyData = intersectBody.pop()) !== undefined) {
       intersectFlag[count++] = bodyData;
     }
     return intersectFlag;
@@ -159,16 +154,17 @@ export function flagIntersection(flag1, flag2) {
 
 function getB64Flag(uint16Arr, flagVersion) {
   try {
-    if (flagVersion == "0") {
+    if (flagVersion === "0") {
       return encodeURIComponent(Buffer.from(uint16Arr).toString("base64"));
-    } else if (flagVersion == "1") {
-      return "1:" +
+    } else if (flagVersion === "1") {
+      return (
+        "1:" +
         encodeURI(
-          btoa(encodeUint16arrToBinary(uint16Arr)).replace(/\//g, "_").replace(
-            /\+/g,
-            "-",
-          ),
-        );
+          btoa(encodeUint16arrToBinary(uint16Arr))
+            .replace(/\//g, "_")
+            .replace(/\+/g, "-")
+        )
+      );
     }
   } catch (e) {
     throw e;

--- a/src/helpers/dnsutil.js
+++ b/src/helpers/dnsutil.js
@@ -15,11 +15,17 @@ export const dnsHeaderSize = 2
 export const dnsPacketHeaderSize = 12
 export const minDNSPacketSize = dnsPacketHeaderSize + 5
 export const maxDNSPacketSize = 4096
+export const cacheSize = 10000
 
 const minRequestTimeout = 5000 // 7s
 const defaultRequestTimeout = 15000 // 15s
 const maxRequestTimeout = 30000 // 30s
+
 const dns = new Dns()
+
+export function cacheSize() {
+  return cacheSize;
+}
 
 export function servfail(qid, qs) {
   if (!qid || !qs) return null

--- a/src/helpers/dnsutil.js
+++ b/src/helpers/dnsutil.js
@@ -112,31 +112,6 @@ export function isBlockable(packet) {
   );
 }
 
-export function cacheKey(packet) {
-  // multiple questions are kind of an undefined behaviour
-  // stackoverflow.com/a/55093896
-  if (!hasSingleQuestion(packet)) return null;
-
-  const name = packet.questions[0].name.trim().toLowerCase();
-  const type = packet.questions[0].type;
-  return name + ":" + type;
-}
-
-// TODO: move this function to cacheutil
-export function updateTtl(decodedDnsPacket, end) {
-  const now = Date.now();
-  const outttl = Math.max(Math.floor((end - now) / 1000), /* grace*/ 30);
-  for (const a of decodedDnsPacket.answers) {
-    if (!optAnswer(a)) a.ttl = outttl;
-  }
-}
-
-export function updateQueryId(decodedDnsPacket, queryId) {
-  if (queryId === decodedDnsPacket.id) return false; // no change
-  decodedDnsPacket.id = queryId;
-  return true;
-}
-
 export function isCname(packet) {
   return hasAnswers(packet) && packet.answers[0].type === "CNAME";
 }

--- a/src/helpers/dnsutil.js
+++ b/src/helpers/dnsutil.js
@@ -16,22 +16,21 @@ export const dnsPacketHeaderSize = 12;
 export const minDNSPacketSize = dnsPacketHeaderSize + 5;
 export const maxDNSPacketSize = 4096;
 
-export const dnsCloudflareSec = "1.1.1.2";
-export const dnsCacheSize = 10000;
-export const ttlGraceSec = 30;
+const _dnsCloudflareSec = "1.1.1.2";
+const _dnsCacheSize = 10000;
 
-const minRequestTimeout = 5000; // 7s
-const defaultRequestTimeout = 15000; // 15s
-const maxRequestTimeout = 30000; // 30s
+const _minRequestTimeout = 5000; // 7s
+const _defaultRequestTimeout = 15000; // 15s
+const _maxRequestTimeout = 30000; // 30s
 
 const dns = new Dns();
 
 export function dnsIpv4() {
-  return dnsCloudflareSec;
+  return _dnsCloudflareSec;
 }
 
 export function cacheSize() {
-  return dnsCacheSize;
+  return _dnsCacheSize;
 }
 
 export function servfail(qid, qs) {
@@ -46,10 +45,10 @@ export function servfail(qid, qs) {
 }
 
 export function requestTimeout() {
-  const t = envutil.workersTimeout(defaultRequestTimeout);
-  return t > minRequestTimeout
-    ? Math.min(t, maxRequestTimeout)
-    : minRequestTimeout;
+  const t = envutil.workersTimeout(_defaultRequestTimeout);
+  return t > _minRequestTimeout
+    ? Math.min(t, _maxRequestTimeout)
+    : _minRequestTimeout;
 }
 
 export function truncated(ans) {
@@ -133,7 +132,6 @@ export function updateTtl(decodedDnsPacket, end) {
 }
 
 export function updateQueryId(decodedDnsPacket, queryId) {
-  if (queryId === 0) return false; // doh reqs are qid free
   if (queryId === decodedDnsPacket.id) return false; // no change
   decodedDnsPacket.id = queryId;
   return true;

--- a/src/helpers/dnsutil.js
+++ b/src/helpers/dnsutil.js
@@ -6,43 +6,50 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { DNSParserWrap as Dns } from "../dns-operation/dnsOperation.js"
-import * as envutil from "./envutil.js"
+import { DNSParserWrap as Dns } from "../dns-operation/dnsOperation.js";
+import * as envutil from "./envutil.js";
 
 // dns packet constants (in bytes)
 // A dns message over TCP stream has a header indicating length.
-export const dnsHeaderSize = 2
-export const dnsPacketHeaderSize = 12
-export const minDNSPacketSize = dnsPacketHeaderSize + 5
-export const maxDNSPacketSize = 4096
-export const cacheSize = 10000
+export const dnsHeaderSize = 2;
+export const dnsPacketHeaderSize = 12;
+export const minDNSPacketSize = dnsPacketHeaderSize + 5;
+export const maxDNSPacketSize = 4096;
 
-const minRequestTimeout = 5000 // 7s
-const defaultRequestTimeout = 15000 // 15s
-const maxRequestTimeout = 30000 // 30s
+export const dnsCloudflareSec = "1.1.1.2";
+export const dnsCacheSize = 10000;
+export const ttlGraceSec = 30;
 
-const dns = new Dns()
+const minRequestTimeout = 5000; // 7s
+const defaultRequestTimeout = 15000; // 15s
+const maxRequestTimeout = 30000; // 30s
+
+const dns = new Dns();
+
+export function dnsIpv4() {
+  return dnsCloudflareSec;
+}
 
 export function cacheSize() {
-  return cacheSize;
+  return dnsCacheSize;
 }
 
 export function servfail(qid, qs) {
-  if (!qid || !qs) return null
+  if (!qid || !qs) return null;
 
   return encode({
     id: qid,
     type: "response",
     flags: 4098, // servfail
     questions: qs,
-  })
+  });
 }
 
 export function requestTimeout() {
-  const t = envutil.workersTimeout(defaultRequestTimeout)
-  return (t > minRequestTimeout) ?
-    Math.min(t, maxRequestTimeout) :
-    minRequestTimeout
+  const t = envutil.workersTimeout(defaultRequestTimeout);
+  return t > minRequestTimeout
+    ? Math.min(t, maxRequestTimeout)
+    : minRequestTimeout;
 }
 
 export function truncated(ans) {
@@ -55,12 +62,11 @@ export function truncated(ans) {
 }
 
 export function validResponseSize(r) {
-  return r && validateSize(r.byteLength)
+  return r && validateSize(r.byteLength);
 }
 
 export function validateSize(sz) {
-  return sz >= minDNSPacketSize &&
-    sz <= maxDNSPacketSize
+  return sz >= minDNSPacketSize && sz <= maxDNSPacketSize;
 }
 
 export function hasAnswers(packet) {
@@ -97,11 +103,14 @@ export function decode(buf) {
 }
 
 export function isBlockable(packet) {
-  return hasSingleQuestion(packet) && (packet.questions[0].type == "A" ||
-    packet.questions[0].type == "AAAA" ||
-    packet.questions[0].type == "CNAME" ||
-    packet.questions[0].type == "HTTPS" ||
-    packet.questions[0].type == "SVCB");
+  return (
+    hasSingleQuestion(packet) &&
+    (packet.questions[0].type === "A" ||
+      packet.questions[0].type === "AAAA" ||
+      packet.questions[0].type === "CNAME" ||
+      packet.questions[0].type === "HTTPS" ||
+      packet.questions[0].type === "SVCB")
+  );
 }
 
 export function cacheKey(packet) {
@@ -109,17 +118,16 @@ export function cacheKey(packet) {
   // stackoverflow.com/a/55093896
   if (!hasSingleQuestion(packet)) return null;
 
-  const name = packet.questions[0].name
-      .trim()
-      .toLowerCase();
+  const name = packet.questions[0].name.trim().toLowerCase();
   const type = packet.questions[0].type;
   return name + ":" + type;
 }
 
+// TODO: move this function to cacheutil
 export function updateTtl(decodedDnsPacket, end) {
   const now = Date.now();
-  const outttl = Math.max(Math.floor((end - now) / 1000), 30); // ttl grace already set during cache put
-  for (let a of decodedDnsPacket.answers) {
+  const outttl = Math.max(Math.floor((end - now) / 1000), /* grace*/ 30);
+  for (const a of decodedDnsPacket.answers) {
     if (!optAnswer(a)) a.ttl = outttl;
   }
 }
@@ -132,37 +140,38 @@ export function updateQueryId(decodedDnsPacket, queryId) {
 }
 
 export function isCname(packet) {
-  return (hasAnswers(packet) && packet.answers[0].type == "CNAME");
+  return hasAnswers(packet) && packet.answers[0].type === "CNAME";
 }
 
 export function isHttps(packet) {
-  return (hasAnswers(packet) &&
-    (packet.answers[0].type == "HTTPS" || packet.answers[0].type == "SVCB"));
+  return (
+    hasAnswers(packet) &&
+    (packet.answers[0].type === "HTTPS" || packet.answers[0].type === "SVCB")
+  );
 }
 
 export function getCname(answers) {
-  let li = [];
+  const li = [];
   li[0] = answers[0].data.trim().toLowerCase();
-  li[1] = answers[answers.length - 1].name.trim()
-    .toLowerCase();
+  li[1] = answers[answers.length - 1].name.trim().toLowerCase();
   return li;
 }
 
 export function dohStatusCode(b) {
-  if (!b || !b.byteLength) return 412
-  if (b.byteLength > maxDNSPacketSize) return 413
-  if (b.byteLength < minDNSPacketSize) return 400
-  return 200
+  if (!b || !b.byteLength) return 412;
+  if (b.byteLength > maxDNSPacketSize) return 413;
+  if (b.byteLength < minDNSPacketSize) return 400;
+  return 200;
 }
 
 export function getTargetName(answers) {
-  let tn = answers[0].data.targetName.trim().toLowerCase();
+  const tn = answers[0].data.targetName.trim().toLowerCase();
   if (tn === ".") return false;
   return tn;
 }
 
 export function getQueryName(questions) {
-  let qn = questions[0].name.trim().toLowerCase();
+  const qn = questions[0].name.trim().toLowerCase();
   if (qn === "") return false;
   return qn;
 }

--- a/src/helpers/env.js
+++ b/src/helpers/env.js
@@ -79,7 +79,7 @@ const _ENV_VAR_MAPPINGS = {
 
   // set to on - off aggressive cache plugin
   // as of now Cache-api is available only on worker
-  // so _loadEnv will set this to false for other runtime.
+  // so load() will set this to false for other runtime.
   isAggCacheReq: {
     name: {
       worker: "IS_AGGRESSIVE_CACHE_REQ",
@@ -132,9 +132,9 @@ function _getRuntimeEnv(runtime) {
   return env;
 }
 
-function _getRuntime() {
+function _determineRuntimeIfPossible() {
   if (typeof Deno !== "undefined") {
-    return "deno";
+    return Deno.env.get("RUNTIME") || "deno";
   }
 
   if (typeof process !== "undefined") {
@@ -143,7 +143,7 @@ function _getRuntime() {
     if (process.env) return process.env.RUNTIME || "node";
   }
 
-  throw new Error("unknown runtime");
+  return null;
 }
 
 export default class EnvManager {
@@ -151,7 +151,7 @@ export default class EnvManager {
    * Initializes the env manager.
    */
   constructor() {
-    this.runtime = _getRuntime();
+    this.runtime = _determineRuntimeIfPossible();
     this.envMap = new Map();
     this.load();
   }
@@ -163,7 +163,7 @@ export default class EnvManager {
   load() {
     const renv = _getRuntimeEnv(this.runtime);
 
-    globalThis.env = renv; // Global `env` namespace.
+    globalThis.env = renv; // global `env` namespace.
 
     for (const [k, v] of Object.entries(renv)) {
       this.envMap.set(k, v);

--- a/src/helpers/envutil.js
+++ b/src/helpers/envutil.js
@@ -10,6 +10,15 @@ export function onFly() {
   return env && env.cloudPlatform === "fly";
 }
 
+export function hasDisk() {
+  // got disk on test nodejs envs and on fly
+  return onFly() || (isNode() && !isProd());
+}
+
+export function isProd() {
+  return env && env.runTimeEnv === "production";
+}
+
 export function isWorkers() {
   return env && env.runTime === "worker";
 }
@@ -21,3 +30,24 @@ export function isNode() {
 export function workersTimeout(defaultValue = 0) {
   return (env && env.workerTimeout) || defaultValue;
 }
+
+export function blocklistUrl() {
+  if (!env) return null;
+  return env.blocklistUrl;
+}
+
+export function timestamp() {
+  if (!env) return null;
+  return env.latestTimestamp;
+}
+
+export function tdNodeCount() {
+  if (!env) return null;
+  return env.tdNodecount;
+}
+
+export function tdParts() {
+  if (!env) return null;
+  return env.tdParts;
+}
+

--- a/src/helpers/node/blocklists.js
+++ b/src/helpers/node/blocklists.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 RethinkDNS and its authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as util from "../util.js";
+import * as envutil from "../envutil.js";
+
+const blocklistsDir = "./blocklists__";
+const tdFile = "td.txt";
+const rdFile = "rd.txt";
+const ftFile = "filetag.json";
+
+export async function setup(bw) {
+
+  if (!bw || !envutil.hasDisk()) return false;
+
+  const now = Date.now();
+  const url = envutil.blocklistUrl();
+  const timestamp = envutil.timestamp();
+  const nodecount = envutil.tdNodeCount();
+  const tdparts = envutil.tdParts();
+
+  const ok = setupLocally(bw, timestamp, nodecount);
+  if (ok) {
+    log.i("bl setup locally tstamp/nc", timestamp, nodecount);
+    return true;
+  }
+
+  log.i("dowloading bl tstamp/nc/parts", timestamp, nodecount, tdparts);
+  await bw.initBlocklistConstruction(
+    now,
+    url,
+    timestamp,
+    nodecount,
+    tdparts
+  );
+
+  save(bw, timestamp);
+}
+
+function save(bw, timestamp) {
+  if (!bw.isBlocklistFilterSetup()) return false;
+
+  mkdirsIfNeeded(timestamp);
+
+  const [tdfp, rdfp, ftfp] = getFilePaths(timestamp);
+
+  // write out array-buffers to disk
+  fs.writeFileSync(tdfp, util.bufferOf(bw.td));
+  fs.writeFileSync(rdfp, util.bufferOf(bw.rd));
+  fs.writeFileSync(ftfp, JSON.stringify(bw.ft));
+
+  log.i("blocklists written to disk");
+
+  return true;
+}
+
+function setupLocally(bw, timestamp, nodecount) {
+  if (!hasBlocklistFiles(timestamp)) return false;
+
+  const [td, rd, ft] = getFilePaths(timestamp);
+  log.i("on-disk td/rd/ft", td, rd, ft);
+
+  const tdbuf = fs.readFileSync(td);
+  const rdbuf = fs.readFileSync(rd);
+  const ftbuf = fs.readFileSync(ft, "utf-8");
+
+  // TODO: file integrity checks
+  const ab0 = util.arrayBufferOf(tdbuf);
+  const ab1 = util.arrayBufferOf(rdbuf);
+  const json1 = JSON.parse(ftbuf);
+  const json2 = { nodecount: nodecount };
+
+  bw.initBlocklistFilterConstruction(
+    /*trie*/ ab0,
+    /*rank-dir*/ ab1,
+    /*file-tag*/ json1,
+    /*basic-config*/ json2
+  );
+
+  return true;
+}
+
+function hasBlocklistFiles(timestamp) {
+  const [td, rd, ft] = getFilePaths(timestamp);
+
+  return fs.existsSync(td) && fs.existsSync(rd) && fs.existsSync(ft);
+}
+
+function getFilePaths(t) {
+  const td = path.normalize(blocklistsDir + "/" + t + "/" + tdFile);
+  const rd = path.normalize(blocklistsDir + "/" + t + "/" + rdFile);
+  const ft = path.normalize(blocklistsDir + "/" + t + "/" + ftFile);
+
+  return [td, rd, ft];
+}
+
+function getDirPaths(t) {
+  const bldir = path.normalize(blocklistsDir);
+  const tsdir = path.normalize(blocklistsDir + "/" + t);
+
+  return [bldir, tsdir];
+}
+
+function mkdirsIfNeeded(timestamp) {
+  const [dir1, dir2] = getDirPaths(timestamp);
+
+  if (!fs.existsSync(dir1)) {
+    log.i("creating blocklist dir", dir1)
+    fs.mkdirSync(dir1);
+  }
+
+  if (!fs.existsSync(dir2)) {
+    log.i("creating timestamp dir", dir2)
+    fs.mkdirSync(dir2);
+  }
+}
+

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -278,3 +278,17 @@ export function mapOf(obj) {
 export function emptyString(str) {
   return !str || str.length === 0;
 }
+
+export function respond204() {
+  return new Response(null, {
+    status: 204, // no content
+    headers: corsHeaders(),
+  });
+}
+
+export function respond503() {
+  return new Response(null, {
+    status: 503, // unavailable
+    headers: dnsHeaders(),
+  });
+}

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -11,7 +11,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Buffer } from "buffer"
+import { Buffer } from "buffer";
 
 /**
  * Encodes a number to an Uint8Array of length `n` in Big Endian byte order.
@@ -23,40 +23,40 @@ import { Buffer } from "buffer"
 export function encodeUint8ArrayBE(n, len) {
   const o = n;
 
-  if (!n) return new Uint8Array(len)
+  if (!n) return new Uint8Array(len);
 
   const a = [];
-  a.unshift(n & 255)
+  a.unshift(n & 255);
   while (n >= 256) {
     n = n >>> 8;
-    a.unshift(n & 255)
+    a.unshift(n & 255);
   }
 
   if (a.length > len) {
-    throw new RangeError(`Cannot encode ${o} in ${len} len Uint8Array`)
+    throw new RangeError(`Cannot encode ${o} in ${len} len Uint8Array`);
   }
 
-  let fill = len - a.length
-  while (fill--) a.unshift(0)
+  let fill = len - a.length;
+  while (fill--) a.unshift(0);
 
-  return new Uint8Array(a)
+  return new Uint8Array(a);
 }
 
 export function fromBrowser(ua) {
-  return ua && ua.startsWith("Mozilla/5.0")
+  return ua && ua.startsWith("Mozilla/5.0");
 }
 
 export function jsonHeaders() {
   return {
     "Content-Type": "application/json",
-  }
+  };
 }
 
 export function dnsHeaders() {
   return {
     "Accept": "application/dns-message",
     "Content-Type": "application/dns-message",
-  }
+  };
 }
 
 export function corsHeaders() {
@@ -73,14 +73,11 @@ export function corsHeaders() {
  */
 export function corsHeadersIfNeeded(ua) {
   // allow cors when user agents claiming to be browsers
-  return (fromBrowser(ua)) ? corsHeaders() : {}
+  return fromBrowser(ua) ? corsHeaders() : {};
 }
 
 export function browserHeaders() {
-  return Object.assign(
-    jsonHeaders(),
-    corsHeaders(),
-  );
+  return Object.assign(jsonHeaders(), corsHeaders());
 }
 
 /**
@@ -88,19 +85,16 @@ export function browserHeaders() {
  * @return {Object} - Headers
  */
 export function dohHeaders(ua) {
-  return Object.assign(
-    dnsHeaders(),
-    corsHeadersIfNeeded(ua),
-  )
+  return Object.assign(dnsHeaders(), corsHeadersIfNeeded(ua));
 }
 
 export function contentLengthHeader(b) {
-  const len = (!b || !b.byteLength) ? "0" : b.byteLength.toString()
-  return { "Content-Length" : len }
+  const len = !b || !b.byteLength ? "0" : b.byteLength.toString();
+  return { "Content-Length": len };
 }
 
-export function concatHeaders() {
-  return Object.assign(...arguments)
+export function concatHeaders(...args) {
+  return Object.assign(...args);
 }
 
 /**
@@ -108,14 +102,14 @@ export function concatHeaders() {
  * @return {Object} - Headers
  */
 export function copyHeaders(request) {
-  const headers = {}
-  if (!request || !request.headers) return headers
+  const headers = {};
+  if (!request || !request.headers) return headers;
 
   // Object.assign, Object spread, etc don't work
   request.headers.forEach((val, name) => {
-    headers[name] = val
-  })
-  return headers
+    headers[name] = val;
+  });
+  return headers;
 }
 export function copyNonPseudoHeaders(req) {
   const headers = {};
@@ -136,37 +130,37 @@ export function copyNonPseudoHeaders(req) {
  */
 export function sleep(ms) {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms)
+    setTimeout(resolve, ms);
   });
 }
 
 export function objOf(map) {
-  return map.entries ? Object.fromEntries(map) : false
+  return map.entries ? Object.fromEntries(map) : false;
 }
 
 // stackoverflow.com/a/31394257
 export function arrayBufferOf(buf) {
-  if (!buf) return null
+  if (!buf) return null;
 
-  const offset = buf.byteOffset
-  const len = buf.byteLength
-  return buf.buffer.slice(offset, offset + len)
+  const offset = buf.byteOffset;
+  const len = buf.byteLength;
+  return buf.buffer.slice(offset, offset + len);
 }
 
 // stackoverflow.com/a/17064149
 export function bufferOf(arrayBuf) {
-  if (!arrayBuf) return null
+  if (!arrayBuf) return null;
 
-  return Buffer.from(new Uint8Array(arrayBuf))
+  return Buffer.from(new Uint8Array(arrayBuf));
 }
 
 export function recycleBuffer(b) {
-  b.fill(0)
-  return 0
+  b.fill(0);
+  return 0;
 }
 
 export function createBuffer(size) {
-  return Buffer.allocUnsafe(size)
+  return Buffer.allocUnsafe(size);
 }
 
 export function timedOp(op, ms, cleanup) {
@@ -207,16 +201,41 @@ export function timedOp(op, ms, cleanup) {
 }
 
 export function timeout(ms, callback) {
-  return setTimeout(callback, ms)
+  if (typeof callback !== "function") return -1;
+  return setTimeout(callback, ms);
 }
 
 // stackoverflow.com/a/8084248
 export function uid() {
   // ex: ".ww8ja208it"
-  return (Math.random() + 1).toString(36).slice(1)
+  return (Math.random() + 1).toString(36).slice(1);
+}
+
+// queues fn in a macro-task queue of the event-loop
+// exec order: github.com/nodejs/node/issues/22257
+export function taskBox(fn) {
+  timeout(/* with 0ms delay*/ 0, () => safeBox(fn));
+}
+
+// queues fn in a micro-task queue
+// ref: MDN: Web/API/HTML_DOM_API/Microtask_guide/In_depth
+// queue-task polyfill: stackoverflow.com/a/61605098
+export function microtaskBox(...fns) {
+  let enqueue = null;
+  if (typeof queueMicroTask === "function") {
+    enqueue = queueMicroTask;
+  } else {
+    const p = Promise.resolve();
+    enqueue = p.then.bind(p);
+  }
+
+  for (const f of fns) {
+    enqueue(() => safeBox(f));
+  }
 }
 
 export function safeBox(fn, defaultResponse = null) {
+  if (typeof fn !== "function") return defaultResponse;
   try {
     return fn();
   } catch (ignore) {}
@@ -228,8 +247,10 @@ export function safeBox(fn, defaultResponse = null) {
  * @return {Boolean}
  */
 export function isDnsMsg(req) {
-  return req.headers.get("Accept") === "application/dns-message" ||
+  return (
+    req.headers.get("Accept") === "application/dns-message" ||
     req.headers.get("Content-Type") === "application/dns-message"
+  );
 }
 
 export function emptyResponse() {
@@ -255,6 +276,5 @@ export function mapOf(obj) {
 }
 
 export function emptyString(str) {
-    return !str || str.length === 0
+  return !str || str.length === 0;
 }
-

--- a/src/helpers/workers/config.js
+++ b/src/helpers/workers/config.js
@@ -1,9 +1,15 @@
+/*
+ * Copyright (c) 2021 RethinkDNS and its authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 import EnvManager from "../env.js";
 import * as system from "../../system.js";
 import Log from "../log.js";
 
-(main => {
-
+((main) => {
   // if we're executing this file, we're on workers
   globalThis.RUNTIME = "worker";
 

--- a/src/helpers/workers/config.js
+++ b/src/helpers/workers/config.js
@@ -1,0 +1,22 @@
+import EnvManager from "../env.js";
+import * as system from "../../system.js";
+import Log from "../log.js";
+
+(main => {
+
+  // if we're executing this file, we're on workers
+  globalThis.RUNTIME = "worker";
+
+  const isProd = globalThis.WORKER_ENV === "production";
+
+  if (!globalThis.envManager) {
+    globalThis.envManager = new EnvManager();
+  }
+
+  globalThis.log = new Log(
+    env.logLevel,
+    isProd // set console level only in prod.
+  );
+
+  system.pub("ready");
+})();

--- a/src/index.js
+++ b/src/index.js
@@ -12,32 +12,9 @@ import EnvManager from "./helpers/env.js";
 import Log from "./helpers/log.js";
 import * as util from "./helpers/util.js";
 import * as dnsutil from "./helpers/dnsutil.js";
-
-if (!globalThis.envManager) globalThis.envManager = new EnvManager();
-
-if (typeof addEventListener !== "undefined") {
-  addEventListener("fetch", (event) => {
-    event.respondWith(handleRequest(event));
-  });
-}
-
-function initEnvIfNeeded() {
-  if (!envManager.isLoaded) {
-    envManager.loadEnv();
-  }
-
-  if (!globalThis.log) {
-    globalThis.log = new Log(
-      env.logLevel,
-
-      // set console level only in production
-      !console.level && env.runTimeEnv === "production"
-    );
-  }
-}
+import * as system from "./system.js";
 
 export function handleRequest(event) {
-  initEnvIfNeeded();
 
   return Promise.race([
     new Promise((accept, _) => {
@@ -51,6 +28,7 @@ export function handleRequest(event) {
       );
     }),
   ]);
+
 }
 
 async function proxyRequest(event) {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ import * as dnsutil from "./helpers/dnsutil.js";
 import * as system from "./system.js";
 
 export function handleRequest(event) {
-
   return Promise.race([
     new Promise((accept, _) => {
       accept(proxyRequest(event));
@@ -28,12 +27,11 @@ export function handleRequest(event) {
       );
     }),
   ]);
-
 }
 
 async function proxyRequest(event) {
   try {
-    if (optionsRequest(event.request)) return respond204();
+    if (optionsRequest(event.request)) return util.respond204();
 
     const currentRequest = new CurrentRequest();
     const plugin = new RethinkPlugin(event);
@@ -53,13 +51,6 @@ function optionsRequest(request) {
   return request.method === "OPTIONS";
 }
 
-function respond204() {
-  return new Response(null, {
-    status: 204, // no content
-    headers: util.corsHeaders(),
-  });
-}
-
 function errorOrServfail(request, err) {
   const UA = request.headers.get("User-Agent");
   if (!util.fromBrowser(UA)) return servfail();
@@ -72,11 +63,5 @@ function errorOrServfail(request, err) {
 }
 
 function servfail() {
-  return new Response(
-    dnsutil.servfail(), // null response
-    {
-      status: 503, // unavailable
-      headers: util.dnsHeaders(),
-    }
-  );
+  return util.respond503();
 }

--- a/src/server-deno.ts
+++ b/src/server-deno.ts
@@ -4,12 +4,11 @@ import "./helpers/deno/config.ts";
 import { handleRequest } from "./index.js";
 import * as system from "./system.js";
 
-(main => {
+((main) => {
   system.sub("go", systemUp);
 })();
 
-function systemUp() {
-
+async function systemUp() {
   const { TERMINATE_TLS, TLS_CRT_PATH, TLS_KEY_PATH } = Deno.env.toObject();
   const HTTP_PORT = 8080;
 
@@ -33,7 +32,6 @@ function systemUp() {
     // To not be blocking, handle each connection without awaiting
     handleHttp(conn);
   }
-
 }
 
 async function handleHttp(conn: Deno.Conn) {
@@ -58,4 +56,3 @@ async function handleHttp(conn: Deno.Conn) {
     }
   }
 }
-

--- a/src/server-deno.ts
+++ b/src/server-deno.ts
@@ -21,8 +21,7 @@ async function systemUp() {
     : Deno.listen({
       port: HTTP_PORT,
     });
-  console.log(
-    `Running HTTP webserver at: http://${(l.addr as Deno.NetAddr).hostname}:${
+  console.log(`deno up at: http://${(l.addr as Deno.NetAddr).hostname}:${
       (l.addr as Deno.NetAddr).port
     }/`,
   );

--- a/src/server-deno.ts
+++ b/src/server-deno.ts
@@ -2,29 +2,38 @@
 // other modules.
 import "./helpers/deno/config.ts";
 import { handleRequest } from "./index.js";
+import * as system from "./system.js";
 
-const { TERMINATE_TLS, TLS_CRT_PATH, TLS_KEY_PATH } = Deno.env.toObject();
-const HTTP_PORT = 8080;
+(main => {
+  system.sub("go", systemUp);
+})();
 
-const l = (TERMINATE_TLS == "true")
-  ? Deno.listenTls({
-    port: HTTP_PORT,
-    certFile: TLS_CRT_PATH,
-    keyFile: TLS_KEY_PATH,
-  })
-  : Deno.listen({
-    port: HTTP_PORT,
-  });
-console.log(
-  `Running HTTP webserver at: http://${(l.addr as Deno.NetAddr).hostname}:${
-    (l.addr as Deno.NetAddr).port
-  }/`,
-);
+function systemUp() {
 
-// Connections to the listener will be yielded up as an async iterable.
-for await (const conn of l) {
-  // To not be blocking, handle each connection without awaiting
-  handleHttp(conn);
+  const { TERMINATE_TLS, TLS_CRT_PATH, TLS_KEY_PATH } = Deno.env.toObject();
+  const HTTP_PORT = 8080;
+
+  const l = (TERMINATE_TLS == "true")
+    ? Deno.listenTls({
+      port: HTTP_PORT,
+      certFile: TLS_CRT_PATH,
+      keyFile: TLS_KEY_PATH,
+    })
+    : Deno.listen({
+      port: HTTP_PORT,
+    });
+  console.log(
+    `Running HTTP webserver at: http://${(l.addr as Deno.NetAddr).hostname}:${
+      (l.addr as Deno.NetAddr).port
+    }/`,
+  );
+
+  // Connections to the listener will be yielded up as an async iterable.
+  for await (const conn of l) {
+    // To not be blocking, handle each connection without awaiting
+    handleHttp(conn);
+  }
+
 }
 
 async function handleHttp(conn: Deno.Conn) {
@@ -49,3 +58,4 @@ async function handleHttp(conn: Deno.Conn) {
     }
   }
 }
+

--- a/src/server-node.js
+++ b/src/server-node.js
@@ -44,8 +44,6 @@ function systemUp() {
     cert: env.tlsCrt,
   };
 
-  log.d("system up with tls", tlsOpts);
-
   const dot1 = tls
     .createServer(tlsOpts, serveTLS)
     .listen(DOT_PORT, () => up("DoT", dot1.address()));

--- a/src/server-node.js
+++ b/src/server-node.js
@@ -34,14 +34,11 @@ const DOH_PORT = DOH_ENTRY_PORT;
 let OUR_RG_DN_RE = null; // regular dns name match
 let OUR_WC_DN_RE = null; // wildcard dns name match
 
-(main => {
-
+((main) => {
   system.sub("go", systemUp);
-
 })();
 
 function systemUp() {
-
   const tlsOpts = {
     key: env.tlsKey,
     cert: env.tlsCrt,

--- a/src/server-node.js
+++ b/src/server-node.js
@@ -11,12 +11,12 @@ import net, { isIPv6, Socket } from "net";
 import tls, { TLSSocket } from "tls";
 import http2, { Http2ServerRequest, Http2ServerResponse } from "http2";
 import { V1ProxyProtocol } from "proxy-protocol-js";
-
+import * as system from "./system.js";
 import { handleRequest } from "./index.js";
 import * as dnsutil from "./helpers/dnsutil.js";
 import * as util from "./helpers/util.js";
 import { copyNonPseudoHeaders } from "./helpers/node/util.js";
-import { TLS_CRT, TLS_KEY } from "./helpers/node/config.js";
+import "./helpers/node/config.js";
 /* eslint-enable no-unused-vars */
 
 // Ports which the services are exposed on. Corresponds to fly.toml ports.
@@ -31,18 +31,26 @@ const DOT_PORT = DOT_IS_PROXY_PROTO
   : DOT_ENTRY_PORT;
 const DOH_PORT = DOH_ENTRY_PORT;
 
-const tlsOptions = {
-  key: TLS_KEY,
-  cert: TLS_CRT,
-};
-
 let OUR_RG_DN_RE = null; // regular dns name match
 let OUR_WC_DN_RE = null; // wildcard dns name match
 
-// main
-((_) => {
+(main => {
+
+  system.sub("go", systemUp);
+
+})();
+
+function systemUp() {
+
+  const tlsOpts = {
+    key: env.tlsKey,
+    cert: env.tlsCrt,
+  };
+
+  log.d("system up with tls", tlsOpts);
+
   const dot1 = tls
-    .createServer(tlsOptions, serveTLS)
+    .createServer(tlsOpts, serveTLS)
     .listen(DOT_PORT, () => up("DoT", dot1.address()));
 
   const dot2 =
@@ -52,13 +60,13 @@ let OUR_WC_DN_RE = null; // wildcard dns name match
       .listen(DOT_PROXY_PORT, () => up("DoT ProxyProto", dot2.address()));
 
   const doh = http2
-    .createSecureServer({ ...tlsOptions, allowHTTP1: true }, serveHTTPS)
+    .createSecureServer({ ...tlsOpts, allowHTTP1: true }, serveHTTPS)
     .listen(DOH_PORT, () => up("DoH", doh.address()));
 
   function up(server, addr) {
     log.i(server, `listening on: [${addr.address}]:${addr.port}`);
   }
-})();
+}
 
 function close(sock) {
   util.safeBox(() => sock.destroy());

--- a/src/server-workers.js
+++ b/src/server-workers.js
@@ -2,8 +2,8 @@ import * as system from "./system.js";
 import "./helpers/workers/config.js";
 import { handleRequest } from "./index.js";
 
-(main => {
-  system.sub("go", systemUp)
+((main) => {
+  system.sub("go", systemUp);
 })();
 
 function systemUp() {
@@ -14,4 +14,3 @@ function systemUp() {
     event.respondWith(handleRequest(event));
   });
 }
-

--- a/src/server-workers.js
+++ b/src/server-workers.js
@@ -1,5 +1,13 @@
-import * as system from "./system.js";
+/*
+ * Copyright (c) 2021 RethinkDNS and its authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 import "./helpers/workers/config.js";
+import * as system from "./system.js";
 import { handleRequest } from "./index.js";
 
 ((main) => {

--- a/src/server-workers.js
+++ b/src/server-workers.js
@@ -7,18 +7,31 @@
  */
 
 import "./helpers/workers/config.js";
-import * as system from "./system.js";
 import { handleRequest } from "./index.js";
+import * as system from "./system.js";
+import * as util from "./helpers/util.js";
+
+let up = false;
 
 ((main) => {
-  system.sub("go", systemUp);
-})();
-
-function systemUp() {
   if (typeof addEventListener === "undefined") {
     throw new Error("workers env missing addEventListener");
   }
-  addEventListener("fetch", (event) => {
-    event.respondWith(handleRequest(event));
-  });
+
+  system.sub("go", systemUp);
+
+  addEventListener("fetch", serveDoh);
+})();
+
+function systemUp() {
+  up = true;
+}
+
+function serveDoh(event) {
+  if (!up) {
+    event.respondWith(util.respond503());
+    return;
+  }
+
+  event.respondWith(handleRequest(event));
 }

--- a/src/server-workers.js
+++ b/src/server-workers.js
@@ -1,0 +1,17 @@
+import * as system from "./system.js";
+import "./helpers/workers/config.js";
+import { handleRequest } from "./index.js";
+
+(main => {
+  system.sub("go", systemUp)
+})();
+
+function systemUp() {
+  if (typeof addEventListener === "undefined") {
+    throw new Error("workers env missing addEventListener");
+  }
+  addEventListener("fetch", (event) => {
+    event.respondWith(handleRequest(event));
+  });
+}
+

--- a/src/system.js
+++ b/src/system.js
@@ -20,15 +20,13 @@ const events = new Set();
 const listeners = new Map();
 
 (() => {
-
-  for (let e of events) {
+  for (const e of events) {
     listeners.set(e, new Set());
   }
 
-  for (let se of stickyEvents) {
+  for (const se of stickyEvents) {
     listeners.set(se, new Set());
   }
-
 })();
 
 export function pub(event) {
@@ -41,10 +39,9 @@ export function pub(event) {
     listeners.delete(event);
   }
 
-  for (let cb of eventCallbacks) {
+  for (const cb of eventCallbacks) {
     util.safeBox(() => cb());
   }
-
 }
 
 export function sub(event, cb) {
@@ -63,4 +60,3 @@ export function sub(event, cb) {
 
   return true;
 }
-

--- a/src/system.js
+++ b/src/system.js
@@ -39,6 +39,7 @@ export function pub(event) {
     listeners.delete(event);
   }
 
+  // callbacks are called async and don't block the caller
   for (const cb of eventCallbacks) {
     util.safeBox(() => cb());
   }

--- a/src/system.js
+++ b/src/system.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021 RethinkDNS and its authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import * as util from "./helpers/util.js";
+
+// once emitted, they stick; firing off new listeners forever, just the once.
+const stickyEvents = new Set([
+  // when env setup is done
+  "ready",
+  // when plugin setup is done
+  "go",
+]);
+
+const events = new Set();
+
+const listeners = new Map();
+
+(() => {
+
+  for (let e of events) {
+    listeners.set(e, new Set());
+  }
+
+  for (let se of stickyEvents) {
+    listeners.set(se, new Set());
+  }
+
+})();
+
+export function pub(event) {
+  const eventCallbacks = listeners.get(event);
+
+  if (!eventCallbacks) return;
+
+  // listeners valid just the once for stickyEvents
+  if (stickyEvents.has(event)) {
+    listeners.delete(event);
+  }
+
+  for (let cb of eventCallbacks) {
+    util.safeBox(() => cb());
+  }
+
+}
+
+export function sub(event, cb) {
+  const callbacks = listeners.get(event);
+
+  if (!callbacks) {
+    // if event is sticky, fire off the listener at once
+    if (stickyEvents.has(event)) {
+      util.safeBox(() => cb());
+      return true;
+    }
+    return false;
+  }
+
+  callbacks.add(cb);
+
+  return true;
+}
+

--- a/src/system.js
+++ b/src/system.js
@@ -39,10 +39,8 @@ export function pub(event) {
     listeners.delete(event);
   }
 
-  // callbacks are called async and don't block the caller
-  for (const cb of eventCallbacks) {
-    util.safeBox(() => cb());
-  }
+  // callbacks are queued async and don't block the caller
+  util.microtaskBox(...eventCallbacks);
 }
 
 export function sub(event, cb) {
@@ -51,7 +49,7 @@ export function sub(event, cb) {
   if (!callbacks) {
     // if event is sticky, fire off the listener at once
     if (stickyEvents.has(event)) {
-      util.safeBox(() => cb());
+      util.microtaskBox(cb);
       return true;
     }
     return false;

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,10 +1,11 @@
 const webpack = require("webpack");
 module.exports = {
+  entry: "./src/server-workers.js",
   target: "webworker",
   plugins: [
     new webpack.IgnorePlugin({
       resourceRegExp:
-        /(^dgram$)|(^http2$)|(\/node\/.*\.js$)|(.*_node\.js$)|(.*\.node\.js$)/,
+        /(^dgram$)|(^http2$)|(\/node\/.*\.js$)|(.*-node\.js$)|(.*\.node\.js$)/,
     }),
   ],
   optimization: {


### PR DESCRIPTION
Since nodejs doesn't respect import sequence (unlike deno), conditionals
are required to initialize global deps like log, env, plugin.services etc.

This is solved with a pub-sub mechanism where-in modules subscribe to events to
know when their deps are up and running. Today, the "config" module, imported
for side-effects from the entrypoints (server-workers.js for workers,
server-deno.ts for deno, and server-node.js for node) of respective runtimes,
initializes "log" and "env" objs, and kicks-off other basic setup. It then
publishes a "ready" event which triggers the "plugin" module, that then inits
essential "services". Once the service init is done, "plugin" publishes a "go"
event. The entrypoints listening on the "go" event now bring up their endpoints
as required and start serving DoH/DoT requests.

This could have been a state-machine, but it is impl as pub-sub, for now.