### PR TITLE
run: cleanup background jobs on exit

### DIFF
--- a/run
+++ b/run
@@ -29,6 +29,11 @@ banner() {
   echo "                                                     ";
 }
 
+cleanup() {
+    kill $(jobs -p)
+}
+trap cleanup EXIT
+
 bgcmd() {
   $1 &
 }


### PR DESCRIPTION
When the script exits interactively via ctrl+c the background jobs linger which prevent running again which out manually killing the jobs.

This change will find and kill those background jobs.