### PR TITLE
chore(eslint): Config to run on JS files only

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,7 +17,18 @@ module.exports = {
     sourceType: "module",
   },
 
-  ignorePatterns: ["node_modules/", "dist/", "worker/", "test/data/cache/"],
+  ignorePatterns: [
+    "node_modules/",
+    "dist/",
+    "worker/",
+    "test/data/cache/",
+
+    // Ignore all files, except JS files
+    "**/*.*",
+    "!**/*.js",
+    "!**/*.mjs",
+    "!**/*.cjs",
+  ],
 
   plugins: ["prettier"],
   rules: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,7 +48,7 @@ module.exports = {
     "valid-jsdoc": 0,
     "quotes": ["error", "double", { allowTemplateLiterals: true }],
     "no-unused-vars": "warn",
-    "new-cap": ["error", { "properties": false }],
+    "new-cap": ["error", { properties: false }],
 
     // Enforces rules from .prettierrc file.
     // These should be fixed automatically with formatting.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,12 +57,14 @@ jobs:
         run: |
           git checkout ${{ env.PR_HEAD_SHA }}
 
-      - name: 🔧 Run eslint on changed files only
+      - name: 🔧 Run eslint on changed JS files only
         run: |
           DIFF=$(git diff --name-only --diff-filter=ACMRT \
             ${{ env.BASE_SHA }}...${{ env.PR_HEAD_SHA }})
 
-          npx eslint $DIFF --cache --fix
+          DIFF_JS=$(echo $DIFF | grep -E "\.(m|c)?js$")
+
+          npx eslint $DIFF_JS --cache --fix
 
       - name: 👀 Look for lint changes
         id: lint-changes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,14 +57,12 @@ jobs:
         run: |
           git checkout ${{ env.PR_HEAD_SHA }}
 
-      - name: 🔧 Run eslint on changed JS files only
+      - name: 🔧 Run eslint on changed files only
         run: |
           DIFF=$(git diff --name-only --diff-filter=ACMRT \
             ${{ env.BASE_SHA }}...${{ env.PR_HEAD_SHA }})
 
-          DIFF_JS=$(echo $DIFF | grep -E "\.(m|c)?js$")
-
-          npx eslint $DIFF_JS --cache --fix
+          npx eslint $DIFF --cache --fix
 
       - name: 👀 Look for lint changes
         id: lint-changes

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "wrangler": "^2.1.15"
   },
   "lint-staged": {
-    "*.js": "eslint --cache --fix",
+    "*.?(m|c)js": "eslint --cache --fix",
     "*.ts": "prettier --write"
   },
   "eslintIgnore": ["src/core/cfg.js"]


### PR DESCRIPTION
`eslint` throws error when fed non-js files.