### PR TITLE
chore(eslint): Config, ignore files without extension

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,11 +23,11 @@ module.exports = {
     "worker/",
     "test/data/cache/",
 
-    // Ignore all files, except JS files
-    "**/*.*",
-    "!**/*.js",
-    "!**/*.mjs",
-    "!**/*.cjs",
+    // Ignore all files, except JS files (which may be in a directory)
+    "*",
+    "!*/",
+    "!*.js",
+    "!*.[mc]js",
   ],
 
   plugins: ["prettier"],


### PR DESCRIPTION
revise gh-97, which failed to ignore extension-less files