### PR TITLE
feat: Add support for Fastly Compute@Edge 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ package-lock.json
 
 # Cache
 .eslintcache
+bin/main.wasm
+pkg/serverless-dns.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #### It's a bird, it's a plane, it's... a self-hosted, pi-hole esque, DNS resolver
 
-_serverless-dns_ is a Pi-Hole esque [content-blocking](https://github.com/serverless-dns/blocklists), serverless, stub DNS-over-HTTPS (DoH) and DNS-over-TLS (DoT) resolver. Runs out-of-the-box on [Cloudflare Workers](https://workers.dev), [Deno Deploy](https://deno.com/deploy), and [Fly.io](https://fly.io/). Free tiers of all these services should be enough to cover 10 to 20 devices worth of DNS traffic per month.
+_serverless-dns_ is a Pi-Hole esque [content-blocking](https://github.com/serverless-dns/blocklists), serverless, stub DNS-over-HTTPS (DoH) and DNS-over-TLS (DoT) resolver. Runs out-of-the-box on [Cloudflare Workers](https://workers.dev), [Deno Deploy](https://deno.com/deploy), [Fastly Compute@Eddge](https://www.fastly.com/products/edge-compute), and [Fly.io](https://fly.io/). Free tiers of all these services should be enough to cover 10 to 20 devices worth of DNS traffic per month.
 
 ### The RethinkDNS resolver
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Pull requests are also checked for code style violations and fixed automatically
 
 Configure [`env.js`](src/core/env.js) if you need to tweak the defaults.
 For Cloudflare Workers, setup env vars in [`wrangler.toml`](wrangler.toml), instead.
+For Fastly Compute@Edge, setup env vars in [`fastly.toml`](fastly.toml), instead.
 
 #### Request flow
 
@@ -226,8 +227,8 @@ in-process lfu caches. To disable caching altogether on all three platfroms, set
 
 #### Cloud
 
-Cloudflare Workers and Deno Deploy are ephemeral, as in, the "process" that serves client requests is not long-lived,
-and in fact, two back-to-back requests may be served by two different [_isolates_](https://developers.cloudflare.com/workers/learning/how-workers-works) ("processes"). Resolver on Fly.io, running Node, is backed by [persistent VMs](https://fly.io/blog/docker-without-docker/) and is hence longer-lived,
+Cloudflare Workers, and Deno Deploy are ephemeral, as in, the "process" that serves client requests is not long-lived,
+and in fact, two back-to-back requests may be served by two different [_isolates_](https://developers.cloudflare.com/workers/learning/how-workers-works) ("processes"). Fastly Compute@Edge is the also ephemeral but does not use isolates, instead Fastly creates and destroys a [wasmtime](https://wasmtime.dev/) sandbox for each request. Resolver on Fly.io, running Node, is backed by [persistent VMs](https://fly.io/blog/docker-without-docker/) and is hence longer-lived,
 like traditional "serverfull" environments.
 
 For Deno Deploy, the code-base is bundled up in a single javascript file with `deno bundle` and then handed off
@@ -235,6 +236,9 @@ to Deno.com.
 
 Cloudflare Workers build-time and runtime configurations are defined in [`wrangler.toml`](wrangler.toml).
 [Webpack5 bundles the files](webpack.config.cjs) in an ESM module which is then uploaded to Cloudflare by _Wrangler_.
+
+Fastly Compute@Edge build-time and runtime configurations are defined in [`fastly.toml`](fastly.toml).
+[Webpack5 bundles the files](webpack.fastly.cjs) in an ESM module which is then uploaded to Fastly by the _Fastly CLI_.
 
 For Fly.io, which runs Node, the runtime directives are defined in [`fly.toml`](fly.toml) (used by `dev` and `live` deployment-types),
 while deploy directives are in [`node.Dockerfile`](node.Dockerfile). [`flyctl`](https://fly.io/docs/flyctl) accordingly sets
@@ -245,6 +249,9 @@ up `serverless-dns` on Fly.io's infrastructure.
 npm run build
 # usually, env-name is prod
 npx wrangler publish [-e <env-name>]
+
+# build and deploy for Fastly Compute@Edge
+fastly compute publish
 
 # build and deploy to fly.io
 npm run build:fly

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For step-by-step instructions, refer:
 | Platform       | Difficulty | Runtime                                | Doc                                                                                     |
 | ---------------| ---------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
 | ⛅ Cloudflare  | Easy       | [v8](https://v8.dev) _Isolates_        | [Hosting on Cloudflare Workers](https://docs.rethinkdns.com/dns/open-source#cloudflare) |
+| Fastly Compute@Edge | Easy  | [Fastly JS](https://js-compute-reference-docs.edgecompute.app/)| [Hosting on Fastly Compute@Edge](https://docs.rethinkdns.com/dns/open-source#fastly) |
 | 🦕 Deno.com    | Moderate   | [Deno](https://deno.land) _Isolates_   | [Hosting on Deno.com](https://docs.rethinkdns.com/dns/open-source#deno-deploy)          |
 | 🪂 Fly.io      | Hard       | [Node](https://nodejs.org) _MicroVM_   | [Hosting on Fly.io](https://docs.rethinkdns.com/dns/open-source#fly-io)                 |
 
@@ -81,6 +82,15 @@ curl -fsSL https://deno.land/install.sh | sh
 
 # run serverless-dns on deno
 ./run d
+```
+
+Fastly:
+```bash
+# install Fastly CLI 
+# https://developer.fastly.com/learning/tools/cli
+
+# run serverless-dns on Fastly Compute@Edge
+./run f
 ```
 
 Wrangler:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ RethinkDNS runs `serverless-dns` in production at these endpoints:
 
 | Cloud platform     | Server locations | Protocol    | Domain                    | Usage                                   |
 |--------------------|------------------|-------------|---------------------------|-----------------------------------------|
-| ⛅ Cloudflare Workers | 200+ ([ping](https://check-host.net/check-ping?host=https://sky.rethinkdns.com))        | DoH         | `sky.rethinkdns.com`    | [configure](https://rethinkdns.com/configure?p=doh)  |
-| 🦕 Deno Deploy        | 30+ ([ping](https://check-host.net/check-ping?host=https://deno.dev))                     | DoH         | _private beta_            |                                         |
+| ⛅ Cloudflare Workers | 200+ ([ping](https://check-host.net/check-ping?host=https://sky.rethinkdns.com))           | DoH         | `sky.rethinkdns.com`    | [configure](https://rethinkdns.com/configure?p=doh)  |
+| 🦕 Deno Deploy        | 30+ ([ping](https://check-host.net/check-ping?host=https://deno.dev))                      | DoH         | _private beta_          |                                         |
+| Fastly Compute@Edge   | 80+ ([ping](https://check-host.net/check-ping?host=https://serverless-dns.edgecompute.app))| DoH         | _private beta_          | [configure](https://rethinkdns.com/configure?p=doh) |
 | 🪂 Fly.io             | 30+ ([ping](https://check-host.net/check-ping?host=https://max.rethinkdns.com))           | DoH and DoT | `max.rethinkdns.com`      | [configure](https://rethinkdns.com/configure?p=dot)  |
 
 Server-side processing takes from 0 milliseconds (ms) to 2ms (median), and end-to-end latency (varies across regions and networks) is between 10ms to 30ms (median).
@@ -19,6 +20,8 @@ Server-side processing takes from 0 milliseconds (ms) to 2ms (median), and end-t
 Cloudflare Workers is the easiest platform to setup `serverless-dns`:
 
 [![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/serverless-dns/serverless-dns)
+
+[![Deploy to Fastly](https://deploy.edgecompute.app/button)](https://deploy.edgecompute.app/deploy)
 
 For step-by-step instructions, refer:
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -1,0 +1,35 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = [""]
+description = "Rethink Free Dns with Blocklist, one click install from github to Fastly"
+language = "javascript"
+manifest_version = 2
+name = "serverless-dns"
+service_id = ""
+
+[local_server]
+
+  [local_server.backends]
+
+  [local_server.dictionaries]
+
+    [local_server.dictionaries.env]
+      format = "inline-toml"
+
+      [local_server.dictionaries.env.contents]
+        env = "development"
+
+[scripts]
+  build = "npm run build:fastly"
+
+[setup]
+
+  [setup.dictionaries]
+
+    [setup.dictionaries.env]
+
+      [setup.dictionaries.env.items]
+
+        [setup.dictionaries.env.items.env]
+          value = "production"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "prepare": "./src/build/pre.sh",
     "build": "npm i && npx webpack --config webpack.config.cjs",
+    "build:fastly": "npm i && npx webpack --config webpack.fastly.cjs && npx js-compute-runtime ./dist/fastly.js",
     "build:fly": "npm i && npx webpack --config webpack.fly.cjs"
   },
   "repository": {
@@ -37,6 +38,7 @@
     "undici": "^4.13.0"
   },
   "devDependencies": {
+    "@fastly/js-compute": "^1.0.1",
     "@types/node": "^16.11.7",
     "buffer": "^6.0.3",
     "clinic": "^11.1.0",
@@ -54,5 +56,7 @@
     "*.?(m|c)js": "eslint --cache --fix",
     "*.ts": "prettier --write"
   },
-  "eslintIgnore": ["src/core/cfg.js"]
+  "eslintIgnore": [
+    "src/core/cfg.js"
+  ]
 }

--- a/run
+++ b/run
@@ -106,6 +106,10 @@ elif [ $runtime = "workers" ] || [ $runtime = "w" ]; then
   echo "note: wrangler v1.16+ required";
   echo "using `which wrangler`";
   start="npx wrangler dev --local";
+elif [ $runtime = "fastly" ] || [ $runtime = "f" ]; then
+  echo "note: Fastly CLI required";
+  echo "using `which fastly`";
+  start="fastly compute serve --skip-verification";
 else
   echo "note: nodejs v16+ required";
   echo "using `which node`";

--- a/src/build/pre.sh
+++ b/src/build/pre.sh
@@ -13,21 +13,43 @@ cwd=`pwd`
 # exec this script from npm or project root
 out="./src/${codec}-${f}"
 out2="./src/${codec}-${f2}"
+name=`uname`
 
 # timestamp: 1667519318.799 stackoverflow.com/a/69400542
-# nowms =`date --utc +"%s.%3N"`
-now=`date --utc +"%s"`
+# nowms =`date -u +"%s.%3N"`
+if [[ $name == "Darwin" ]]
+then
+    now=`date -u +"%s"`
+else
+    now=`date --utc +"%s"`
+fi
+
 
 # date from timestamp: stackoverflow.com/a/16311821
-day=`date -d @$now "+%d"`
+if [[ $name == "Darwin" ]]
+then
+    day=`date -r $now "+%d"`
+else
+    day=`date -d @$now "+%d"`
+fi
 # ex: conv 08 => 8 stackoverflow.com/a/12821845
 day=${day#0}
 # week; ceil: stackoverflow.com/a/12536521
 wkdef=$(((day + 7 -1) / 7))
 # year
-yyyydef=`date -d @$now "+%Y"`
+if [[ $name == "Darwin" ]]
+then
+    yyyydef=`date -r $now "+%Y"`
+else
+    yyyydef=`date -d @$now "+%Y"`
+fi
 # month
-mmdef=`date -d @$now "+%m"`
+if [[ $name == "Darwin" ]]
+then
+    mmdef=`date -r $now "+%m"`
+else
+    mmdef=`date -d @$now "+%m"`
+fi
 
 # defaults: stackoverflow.com/a/28085062
 : "${wk:=$wkdef}" "${mm:=$mmdef}" "${yyyy:=$yyyydef}"

--- a/src/commons/envutil.js
+++ b/src/commons/envutil.js
@@ -34,6 +34,12 @@ export function onDenoDeploy() {
   return envManager.get("CLOUD_PLATFORM") === "deno-deploy";
 }
 
+export function onFastly() {
+  if (!envManager) return false;
+
+  return envManager.get("CLOUD_PLATFORM") === "fastly";
+}
+
 export function onCloudflare() {
   if (!envManager) return false;
 
@@ -45,7 +51,7 @@ export function onCloudflare() {
 export function onLocal() {
   if (!envManager) return false;
 
-  return !onFly() && !onDenoDeploy() && !onCloudflare();
+  return !onFly() && !onDenoDeploy() && !onCloudflare() && !onFastly();
 }
 
 export function hasDisk() {
@@ -54,7 +60,7 @@ export function hasDisk() {
 }
 
 export function hasDynamicImports() {
-  if (onDenoDeploy() || onCloudflare()) return false;
+  if (onDenoDeploy() || onCloudflare() || onFastly()) return false;
   return true;
 }
 
@@ -66,6 +72,12 @@ export function isWorkers() {
   if (!envManager) return false;
 
   return envManager.r() === "worker";
+}
+
+export function isFastly() {
+  if (!envManager) return false;
+
+  return envManager.r() === "fastly";
 }
 
 export function isNode() {

--- a/src/core/env.js
+++ b/src/core/env.js
@@ -348,9 +348,6 @@ export default class EnvManager {
     } else if (this.runtime === "deno") {
       v = Deno.env.get(k);
     } else if (this.runtime === "fastly") {
-      if (!globalThis.fastlyEnv) {
-        globalThis.fastlyEnv = new Dictionary("env");
-      }
       v = fastlyEnv.get(k);
     } else if (this.runtime === "worker") {
       v = globalThis.wenv[k];

--- a/src/core/fastly/config.js
+++ b/src/core/fastly/config.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 RethinkDNS and its authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import EnvManager from "../env.js";
+import * as system from "../../system.js";
+import Log from "../log.js";
+import { services } from "../svc.js";
+
+system.when("prepare").then(prep);
+system.when("steady").then(up);
+
+// on Fastly, setup is called for every new request,
+// since server-fastly.js fires "prepare" on every request
+function prep() {
+  if (!globalThis.envManager) {
+    globalThis.envManager = new EnvManager();
+  }
+
+  const isProd = envManager.get("env") === "production";
+
+  if (!globalThis.log) {
+    globalThis.log = new Log({
+      level: envManager.get("LOG_LEVEL"),
+      levelize: isProd, // levelize only in prod
+      withTimestamps: false, // no need to log ts on fastly
+    });
+  }
+
+  // on Fastly, the network-context isn't available in global-scope
+  // ie network requests, for ex over fetch-api or xhr, don't work.
+  // And so, system ready event is published by the event listener
+  // which has the network-context, that is necessary for svc.js
+  // to setup blocklist-filter, which otherwise fails when invoked
+  // from global-scope (such as the "main" function in this file).
+  system.pub("ready");
+}
+
+function up() {
+  if (!services.ready) {
+    log.e("services not yet ready, and we've got a sig-up?!");
+    return;
+  }
+  // nothing else to do on sig-up on Fastly; fire a sig-go!
+  system.pub("go");
+}

--- a/src/core/fastly/config.js
+++ b/src/core/fastly/config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 RethinkDNS and its authors.
+ * Copyright (c) 2022 RethinkDNS and its authors.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,6 +9,7 @@ import EnvManager from "../env.js";
 import * as system from "../../system.js";
 import Log from "../log.js";
 import { services } from "../svc.js";
+import { allowDynamicBackends } from "fastly:experimental";
 
 system.when("prepare").then(prep);
 system.when("steady").then(up);
@@ -16,6 +17,13 @@ system.when("steady").then(up);
 // on Fastly, setup is called for every new request,
 // since server-fastly.js fires "prepare" on every request
 function prep() {
+  allowDynamicBackends(true);
+
+  // This is used within `EnvManager`
+  if (!globalThis.fastlyEnv) {
+    globalThis.fastlyEnv = new Dictionary("env");
+  }
+
   if (!globalThis.envManager) {
     globalThis.envManager = new EnvManager();
   }

--- a/src/server-fastly.js
+++ b/src/server-fastly.js
@@ -2,7 +2,7 @@
 /// <reference types="@fastly/js-compute" />
 
 /*
- * Copyright (c) 2021 RethinkDNS and its authors.
+ * Copyright (c) 2022 RethinkDNS and its authors.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,10 +13,6 @@ import "./core/fastly/config.js";
 import { handleRequest } from "./core/doh.js";
 import * as system from "./system.js";
 import * as util from "./commons/util.js";
-
-import { allowDynamicBackends } from "fastly:experimental";
-
-allowDynamicBackends(true);
 
 addEventListener("fetch", (event) => {
   return serveDoh(event);

--- a/src/server-fastly.js
+++ b/src/server-fastly.js
@@ -1,0 +1,44 @@
+// eslint-disable-next-line spaced-comment
+/// <reference types="@fastly/js-compute" />
+
+/*
+ * Copyright (c) 2021 RethinkDNS and its authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import "./core/fastly/config.js";
+import { handleRequest } from "./core/doh.js";
+import * as system from "./system.js";
+import * as util from "./commons/util.js";
+
+import { allowDynamicBackends } from "fastly:experimental";
+
+allowDynamicBackends(true);
+
+addEventListener("fetch", (event) => {
+  return serveDoh(event);
+});
+
+async function serveDoh(event) {
+  // on Fastly, the network-context is only available in an event listener
+  // and so, publish system prepare from here instead of from main which
+  // runs in global-scope.
+  system.pub("prepare");
+
+  const fetchEvent = util.mkFetchEvent(
+    event.request,
+    null,
+    event.waitUntil.bind(event)
+  );
+
+  try {
+    await system.when("go");
+    return await handleRequest(fetchEvent);
+  } catch (e) {
+    console.error("server", "serveDoh err", e);
+    return util.respond405();
+  }
+}

--- a/webpack.fastly.cjs
+++ b/webpack.fastly.cjs
@@ -22,6 +22,7 @@ module.exports = {
     }),
     new webpack.IgnorePlugin({
       resourceRegExp:
+        // eslint-disable-next-line max-len
         /(^dgram$)|(^http2$)|(\/deno\/.*\.ts$)|(.*-deno\.ts$)|(.*\.deno\.ts$)|(\/node\/.*\.js$)|(.*-node\.js$)|(.*\.node\.js$)/,
     }),
     // stackoverflow.com/a/65556946

--- a/webpack.fastly.cjs
+++ b/webpack.fastly.cjs
@@ -1,0 +1,58 @@
+const webpack = require("webpack");
+const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+
+module.exports = {
+  entry: "./src/server-fastly.js",
+  target: ["webworker", "es2020"],
+  mode: "production",
+  // enable devtool in development
+  // devtool: 'eval-cheap-module-source-map',
+
+  // gist.github.com/ef4/d2cf5672a93cf241fd47c020b9b3066a
+  resolve: {
+    fallback: {
+      // buffer polyfill: archive.is/7OBM7
+      buffer: require.resolve("buffer/"),
+    },
+  },
+
+  plugins: [
+    new webpack.ProvidePlugin({
+      Buffer: ["buffer", "Buffer"],
+    }),
+    new webpack.IgnorePlugin({
+      resourceRegExp:
+        /(^dgram$)|(^http2$)|(\/deno\/.*\.ts$)|(.*-deno\.ts$)|(.*\.deno\.ts$)|(\/node\/.*\.js$)|(.*-node\.js$)|(.*\.node\.js$)/,
+    }),
+    // stackoverflow.com/a/65556946
+    new NodePolyfillPlugin(),
+  ],
+
+  optimization: {
+    usedExports: true,
+    minimize: false,
+  },
+
+  experiments: {
+    outputModule: true,
+  },
+
+  // stackoverflow.com/a/68916455
+  output: {
+    library: {
+      type: "module",
+    },
+    filename: "fastly.js",
+    module: true,
+  },
+  externals: [
+    ({request,}, callback) => {
+      // Allow Webpack to handle fastly:* namespaced module imports by treating
+      // them as modules rather than try to process them as URLs
+      if (/^fastly:.*$/.test(request)) {
+        return callback(null, 'commonjs ' + request);
+      }
+      callback();
+    }
+  ],
+};

--- a/webpack.fastly.cjs
+++ b/webpack.fastly.cjs
@@ -47,13 +47,13 @@ module.exports = {
     module: true,
   },
   externals: [
-    ({request,}, callback) => {
+    ({ request }, callback) => {
       // Allow Webpack to handle fastly:* namespaced module imports by treating
       // them as modules rather than try to process them as URLs
       if (/^fastly:.*$/.test(request)) {
-        return callback(null, 'commonjs ' + request);
+        return callback(null, "commonjs " + request);
       }
       callback();
-    }
+    },
   ],
 };


### PR DESCRIPTION
This adds support for Fastly's Compute@Edge platform and includes a fastly.toml with default values, which anyone can use to deploy to their Fastly account via `fastly compute publish`. That's the only command they would nede to run ☺️ 

When working on this, I found `pre.sh` would not run on OS X, I have modified the script to be compatible with OS X when the script is running on OS X 👍 

Please let me know if you have any questions or feedback for this work