### PR TITLE
fix: Make Fastly C@E application return correct HTTP responses and fix other bugs related to running on C@E

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RethinkDNS runs `serverless-dns` in production at these endpoints:
 |--------------------|------------------|-------------|---------------------------|-----------------------------------------|
 | ⛅ Cloudflare Workers | 200+ ([ping](https://check-host.net/check-ping?host=https://sky.rethinkdns.com))           | DoH         | `sky.rethinkdns.com`    | [configure](https://rethinkdns.com/configure?p=doh)  |
 | 🦕 Deno Deploy        | 30+ ([ping](https://check-host.net/check-ping?host=https://deno.dev))                      | DoH         | _private beta_          |                                         |
-| Fastly Compute@Edge   | 80+ ([ping](https://check-host.net/check-ping?host=https://serverless-dns.edgecompute.app))| DoH         | _private beta_          | [configure](https://rethinkdns.com/configure?p=doh) |
+| 🕐 Fastly Compute@Edge   | 80+ ([ping](https://check-host.net/check-ping?host=https://serverless-dns.edgecompute.app))| DoH         | _private beta_          | [configure](https://rethinkdns.com/configure?p=doh) |
 | 🪂 Fly.io             | 30+ ([ping](https://check-host.net/check-ping?host=https://max.rethinkdns.com))           | DoH and DoT | `max.rethinkdns.com`      | [configure](https://rethinkdns.com/configure?p=dot)  |
 
 Server-side processing takes from 0 milliseconds (ms) to 2ms (median), and end-to-end latency (varies across regions and networks) is between 10ms to 30ms (median).
@@ -28,7 +28,7 @@ For step-by-step instructions, refer:
 | Platform       | Difficulty | Runtime                                | Doc                                                                                     |
 | ---------------| ---------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
 | ⛅ Cloudflare  | Easy       | [v8](https://v8.dev) _Isolates_        | [Hosting on Cloudflare Workers](https://docs.rethinkdns.com/dns/open-source#cloudflare) |
-| Fastly Compute@Edge | Easy  | [Fastly JS](https://js-compute-reference-docs.edgecompute.app/)| [Hosting on Fastly Compute@Edge](https://docs.rethinkdns.com/dns/open-source#fastly) |
+| 🕐 Fastly Compute@Edge | Easy  | [Fastly JS](https://js-compute-reference-docs.edgecompute.app/)| [Hosting on Fastly Compute@Edge](https://docs.rethinkdns.com/dns/open-source#fastly) |
 | 🦕 Deno.com    | Moderate   | [Deno](https://deno.land) _Isolates_   | [Hosting on Deno.com](https://docs.rethinkdns.com/dns/open-source#deno-deploy)          |
 | 🪂 Fly.io      | Hard       | [Node](https://nodejs.org) _MicroVM_   | [Hosting on Fly.io](https://docs.rethinkdns.com/dns/open-source#fly-io)                 |
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -19,6 +19,7 @@ service_id = ""
 
       [local_server.dictionaries.env.contents]
         env = "development"
+        CLOUD_PLATFORM = "fastly"
 
 [scripts]
   build = "npm run build:fastly"
@@ -33,3 +34,5 @@ service_id = ""
 
         [setup.dictionaries.env.items.env]
           value = "production"
+        [setup.dictionaries.env.items.CLOUD_PLATFORM]
+          value = "fastly"

--- a/src/core/doh.js
+++ b/src/core/doh.js
@@ -24,7 +24,9 @@ async function proxyRequest(event) {
   try {
     const plugin = new RethinkPlugin(event);
     await plugin.initIoState(io);
-
+    if (io.httpResponse) {
+      return io.httpResponse;
+    }
     await util.timedSafeAsyncOp(
       /* op*/ async () => plugin.execute(),
       /* waitMs*/ dnsutil.requestTimeout(),

--- a/src/core/doh.js
+++ b/src/core/doh.js
@@ -25,6 +25,8 @@ async function proxyRequest(event) {
     const plugin = new RethinkPlugin(event);
     await plugin.initIoState(io);
     if (io.httpResponse) {
+      const ua = event.request.headers.get("User-Agent");
+      if (util.fromBrowser(ua)) io.setCorsHeadersIfNeeded();
       return io.httpResponse;
     }
     await util.timedSafeAsyncOp(

--- a/src/core/log.js
+++ b/src/core/log.js
@@ -163,13 +163,13 @@ export default class Log {
         this.d = console.debug;
         this.debug = console.debug;
       case "timer":
-        this.lapTime = console.timeLog;
+        this.lapTime = console.timeLog || stub();
         this.startTime = function (name) {
           name += uid();
-          console.time(name);
+          if (console.time) console.time(name);
           return name;
         };
-        this.endTime = console.timeEnd;
+        this.endTime = console.timeEnd || stub();
       case "info":
         this.i = console.info;
         this.info = console.info;

--- a/src/core/log.js
+++ b/src/core/log.js
@@ -163,13 +163,13 @@ export default class Log {
         this.d = console.debug;
         this.debug = console.debug;
       case "timer":
-        this.lapTime = console.timeLog || stub();
+        this.lapTime = console.timeLog || stub(); // Stubbing required for Fastly as they do not currently support this method.
         this.startTime = function (name) {
           name += uid();
           if (console.time) console.time(name);
           return name;
         };
-        this.endTime = console.timeEnd || stub();
+        this.endTime = console.timeEnd || stub(); // Stubbing required for Fastly as they do not currently support this method.
       case "info":
         this.i = console.info;
         this.info = console.info;

--- a/src/server-fastly.js
+++ b/src/server-fastly.js
@@ -15,7 +15,7 @@ import * as system from "./system.js";
 import * as util from "./commons/util.js";
 
 addEventListener("fetch", (event) => {
-  return serveDoh(event);
+  return event.respondWith(serveDoh(event));
 });
 
 async function serveDoh(event) {


### PR DESCRIPTION
This now works correctly on Fastly and here is a godnsbench result! :D

```
❯ godnsbench -a https://serverless-dns.edgecompute.app/ -p 10 -c 10 --verbose


97552#1 [info] Run godnsbench with the following configuration:
{
    "Address": "https://serverless-dns.edgecompute.app/",
    "Connections": 10,
    "Query": "example.org",
    "Timeout": 10,
    "Rate": 0,
    "QueriesCount": 10,
    "Verbose": true,
    "LogOutput": ""
}
97552#20 [info] Starting the test and running 10 connections in parallel
97552#30 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 2.962167ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#30 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#30 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#130 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#28 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 12.340833ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#28 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#29 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 12.256708ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#28 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#29 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#29 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#69 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#85 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#21 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 14.797083ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#21 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#27 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 15.390833ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#25 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 15.581208ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#27 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#23 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 15.084459ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#27 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#25 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#23 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#25 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#38 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#21 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#101 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#26 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 15.395125ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#22 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 15.061375ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#147 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#23 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#22 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#26 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#22 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#26 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#12 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#72 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#117 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#130 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 13.732959ms
97552#24 [debug] github.com/AdguardTeam/dnsproxy/upstream.lookup(): successfully finished lookup for serverless-dns.edgecompute.app in 18.721958ms using . Result : [{199.232.57.51 } {2a04:4e42:4b::307 }]
97552#24 [debug] using HTTP/2 for this upstream: HTTP3 support is not enabled
97552#24 [debug] https://serverless-dns.edgecompute.app:443/: sending request A example.org.
97552#106 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): Dialing to 199.232.57.51:443
97552#69 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 9.389666ms
97552#85 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 10.587042ms
97552#38 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 12.845291ms
97552#106 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 22.950625ms
97552#117 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 26.11975ms
97552#72 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 26.155709ms
97552#101 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 26.437166ms
97552#12 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 26.173375ms
97552#147 [debug] github.com/AdguardTeam/dnsproxy/upstream.(*bootstrapper).createDialContext.func1(): dialer has successfully initialized connection to 199.232.57.51:443 in 26.315959ms
97552#30 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#29 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#28 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#26 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#27 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#22 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#24 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#25 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#21 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#23 [debug] https://serverless-dns.edgecompute.app:443/: response: ok
97552#20 [info] Finished running all connections
97552#1 [info] The test has finished.
97552#1 [info] The test results are:
97552#1 [info] Elapsed: 132.734209ms
97552#1 [info] Average QPS: 75.331174
97552#1 [info] Processed queries: 10
97552#1 [info] Average per query: 13.2782ms
97552#1 [info] Errors count: 0
```