### PR TITLE
env: add disclaimer that DoH, DoT and DoQ upstreams are compatible

### DIFF
--- a/src/core/env.js
+++ b/src/core/env.js
@@ -113,12 +113,12 @@ const defaults = new Map(
       type: "string",
       default: "https://cfstore.rethinkdns.com/blocklists/",
     },
-    // primary DoH upstream (DoH, DoT, DoQ upstreams are compatible)
+    // primary upstream (DoH, DoT, DoQ upstreams are compatible)
     CF_DNS_RESOLVER_URL: {
       type: "string",
       default: "https://cloudflare-dns.com/dns-query",
     },
-    // secondary DoH upstream (DoH, DoT, DoQ upstreams are compatible)
+    // secondary upstream (DoH, DoT, DoQ upstreams are compatible)
     CF_DNS_RESOLVER_URL_2: {
       type: "string",
       default: "https://dns.google/dns-query",

--- a/src/core/env.js
+++ b/src/core/env.js
@@ -113,12 +113,12 @@ const defaults = new Map(
       type: "string",
       default: "https://cfstore.rethinkdns.com/blocklists/",
     },
-    // primary doh upstream
+    // primary DoH upstream (DoH, DoT, DoQ upstreams are compatible)
     CF_DNS_RESOLVER_URL: {
       type: "string",
       default: "https://cloudflare-dns.com/dns-query",
     },
-    // secondary doh upstream
+    // secondary DoH upstream (DoH, DoT, DoQ upstreams are compatible)
     CF_DNS_RESOLVER_URL_2: {
       type: "string",
       default: "https://dns.google/dns-query",


### PR DESCRIPTION
Doing a lot of worker testing is making me learn a lot about the capabilities of serverless-dns. I found that DNS over Quic and DNS over TLS are compatible upstream “names” alongside DoH. For example, quic://p1.freedns.controld.com/dns-query worked as an upstream name. This new “documentation” should clear up some confusion.  

Unsure if other protocols are compatible aswell