### PR TITLE
Fix code bugs

### DIFF
--- a/src/plugins/command-control/cc.js
+++ b/src/plugins/command-control/cc.js
@@ -152,7 +152,7 @@ export class CommandControl {
         response.data.httpResponse = domainNameToUint(
           this.resolver,
           queryString,
-          blf
+          function domainNameToUint(blf) {
         );
       } else if (command === "search") {
         // redirect to the search page with blockstamp (b64) preloaded

--- a/src/plugins/rdns-util.js
+++ b/src/plugins/rdns-util.js
@@ -486,5 +486,4 @@ export function blocklists(strflag) {
   } else {
     throw new Error("unknown blocklist version: " + flagVersion);
   }
-  return blocklists;
 }


### PR DESCRIPTION
With the blf change, it is because 3 arguments were given which can only do 2. 

The blocklist change is because it is unused

both were signaled as bugs from sonarcloud and changing to that removed the “signal” of those being bugs. These 2 coding areas are the only bugs says sonarcloud also and changing this moves reliability from a D to an A