### PR TITLE
Deno v1.31.0

### DIFF
--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_REF }}
           fetch-depth: 0

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -64,7 +64,7 @@ jobs:
       contents: read
     steps:
       - name: 🚚 Fetch code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.git-ref || github.ref }}
           fetch-depth: 0
@@ -85,10 +85,10 @@ jobs:
           git reset
           git merge origin/${BUILD_BRANCH} || :
 
-      - name: 🦕 Install Deno @1.29
+      - name: 🦕 Install Deno @1.31
         uses: denoland/setup-deno@main
         with:
-          deno-version: 1.29.3
+          deno-version: 1.31.0
 
       - name: 📦 Bundle up
         if: ${{ env.DEPLOY_MODE == 'action' }}
@@ -103,7 +103,7 @@ jobs:
       - name: 🤸🏼 Deploy to deno.com
         id: dd
         if: ${{ env.DEPLOY_MODE == 'action' }}
-        uses: denoland/deployctl@1.4.0
+        uses: denoland/deployctl@1.6.0
         with:
           project: ${{ env.PROJECT_NAME }}
           entrypoint: ${{ env.OUT_FILE }}

--- a/.github/workflows/deno-deploy.yml
+++ b/.github/workflows/deno-deploy.yml
@@ -103,7 +103,7 @@ jobs:
       - name: 🤸🏼 Deploy to deno.com
         id: dd
         if: ${{ env.DEPLOY_MODE == 'action' }}
-        uses: denoland/deployctl@1.6.0
+        uses: denoland/deployctl@1.5.0
         with:
           project: ${{ env.PROJECT_NAME }}
           entrypoint: ${{ env.OUT_FILE }}

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🚚 Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_REF }}
           fetch-depth: 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🚚 Get latest code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           # Checkout base (target) repo
           ref: ${{ env.GH_REF }}

--- a/.github/workflows/profiler.yml
+++ b/.github/workflows/profiler.yml
@@ -41,7 +41,7 @@ env:
   JS_RUNTIME: 'node'
   MAXTIME_SEC: '30s'
   NODE_VER: '19.x'
-  DENO_VER: '1.29.3'
+  DENO_VER: '1.31.0'
   MODE: 'p1'
   QDOH: 'q'
 
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: 🍌 Checkout
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_REF }}
           fetch-depth: 0
@@ -68,7 +68,7 @@ jobs:
       # docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs-or-python
       - name: 🐎 Setup Node @v19
         if: env.JS_RUNTIME == 'node'
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VER }}
 
@@ -80,7 +80,7 @@ jobs:
           npm run build --if-present
 
       # deno.com/blog/deploy-static-files#example-a-statically-generated-site
-      - name: 🦕 Setup Deno @1.29.3
+      - name: 🦕 Setup Deno @1.31.0
         if: env.JS_RUNTIME == 'deno'
         uses: denoland/setup-deno@main
         with:

--- a/deno.Dockerfile
+++ b/deno.Dockerfile
@@ -1,11 +1,11 @@
 # Based on github.com/denoland/deno_docker/blob/main/alpine.dockerfile
 
-ARG DENO_VERSION=1.29.2
+ARG DENO_VERSION=1.31.0
 ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
 
 FROM ${BIN_IMAGE} AS bin
 
-FROM frolvlad/alpine-glibc:alpine-3.13
+FROM frolvlad/alpine-glibc:alpine-3.17
 
 RUN apk --no-cache add ca-certificates
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,10 +1,10 @@
 {
   "imports": {
-    "buffer": "https://deno.land/std@0.171.0/node/buffer.ts",
-    "os" : "https://deno.land/std@0.171.0/node/os.ts",
-    "process": "https://deno.land/std@0.171.0/node/process.ts",
+    "buffer": "https://deno.land/std@0.178.0/node/buffer.ts",
+    "os" : "https://deno.land/std@0.178.0/node/os.ts",
+    "process": "https://deno.land/std@0.178.0/node/process.ts",
     "@serverless-dns/dns-parser": "https://github.com/serverless-dns/dns-parser/raw/v2.1.2/index.js",
-    "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.4.1/lfu.js",
-    "@serverless-dns/trie/": "https://github.com/serverless-dns/trie/raw/v0.0.13/src/"
+    "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.4.2/lfu.js",
+    "@serverless-dns/trie/": "https://github.com/serverless-dns/trie/raw/v0.0.15/src/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,8 +1,5 @@
 {
   "imports": {
-    "buffer": "https://deno.land/std@0.178.0/node/buffer.ts",
-    "os" : "https://deno.land/std@0.178.0/node/os.ts",
-    "process": "https://deno.land/std@0.178.0/node/process.ts",
     "@serverless-dns/dns-parser": "https://github.com/serverless-dns/dns-parser/raw/v2.1.2/index.js",
     "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.4.2/lfu.js",
     "@serverless-dns/trie/": "https://github.com/serverless-dns/trie/raw/v0.0.15/src/"

--- a/import_map.json
+++ b/import_map.json
@@ -4,7 +4,7 @@
     "os" : "https://deno.land/std@0.177.0/node/os.ts",
     "process": "https://deno.land/std@0.177.0/node/process.ts",
     "@serverless-dns/dns-parser": "https://github.com/serverless-dns/dns-parser/raw/v2.1.2/index.js",
-    "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.5.0/lfu.js",
+    "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.4.2/lfu.js",
     "@serverless-dns/trie/": "https://github.com/serverless-dns/trie/raw/v0.0.15/src/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -4,7 +4,7 @@
     "os" : "https://deno.land/std@0.177.0/node/os.ts",
     "process": "https://deno.land/std@0.177.0/node/process.ts",
     "@serverless-dns/dns-parser": "https://github.com/serverless-dns/dns-parser/raw/v2.1.2/index.js",
-    "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.4.2/lfu.js",
+    "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.5.0/lfu.js",
     "@serverless-dns/trie/": "https://github.com/serverless-dns/trie/raw/v0.0.15/src/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,5 +1,8 @@
 {
   "imports": {
+    "buffer": "https://deno.land/std@0.178.0/node/buffer.ts",
+    "os" : "https://deno.land/std@0.178.0/node/os.ts",
+    "process": "https://deno.land/std@0.178.0/node/process.ts",
     "@serverless-dns/dns-parser": "https://github.com/serverless-dns/dns-parser/raw/v2.1.2/index.js",
     "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.4.2/lfu.js",
     "@serverless-dns/trie/": "https://github.com/serverless-dns/trie/raw/v0.0.15/src/"

--- a/import_map.json
+++ b/import_map.json
@@ -1,8 +1,8 @@
 {
   "imports": {
-    "buffer": "https://deno.land/std@0.178.0/node/buffer.ts",
-    "os" : "https://deno.land/std@0.178.0/node/os.ts",
-    "process": "https://deno.land/std@0.178.0/node/process.ts",
+    "buffer": "https://deno.land/std@0.177.0/node/buffer.ts",
+    "os" : "https://deno.land/std@0.177.0/node/os.ts",
+    "process": "https://deno.land/std@0.177.0/node/process.ts",
     "@serverless-dns/dns-parser": "https://github.com/serverless-dns/dns-parser/raw/v2.1.2/index.js",
     "@serverless-dns/lfu-cache": "https://github.com/serverless-dns/lfu-cache/raw/v3.4.2/lfu.js",
     "@serverless-dns/trie/": "https://github.com/serverless-dns/trie/raw/v0.0.15/src/"

--- a/node.Dockerfile
+++ b/node.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19 as setup
+FROM node:19 AS setup
 # git is required if any of the npm packages are git[hub] packages
 RUN apt-get update && apt-get install git -yq --no-install-suggests --no-install-recommends
 WORKDIR /node-dir

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@serverless-dns/dns-parser": "github:serverless-dns/dns-parser#v2.1.2",
-    "@serverless-dns/lfu-cache": "github:serverless-dns/lfu-cache#v3.4.2",
+    "@serverless-dns/lfu-cache": "github:serverless-dns/lfu-cache#v3.5.0",
     "@serverless-dns/trie": "github:serverless-dns/trie#v0.0.15",
     "httpx-server": "^1.4.4",
     "node-polyfill-webpack-plugin": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@serverless-dns/dns-parser": "github:serverless-dns/dns-parser#v2.1.2",
-    "@serverless-dns/lfu-cache": "github:serverless-dns/lfu-cache#v3.5.0",
+    "@serverless-dns/lfu-cache": "github:serverless-dns/lfu-cache#v3.4.2",
     "@serverless-dns/trie": "github:serverless-dns/trie#v0.0.15",
     "httpx-server": "^1.4.4",
     "node-polyfill-webpack-plugin": "^2.0.1",

--- a/src/core/deno/config.ts
+++ b/src/core/deno/config.ts
@@ -4,7 +4,7 @@ import * as dbip from "./dbip.ts";
 import { services, stopAfter } from "../svc.js";
 import Log, { LogLevels } from "../log.js";
 import EnvManager from "../env.js";
-import { signal } from "https://deno.land/std@0.178.0/signal/mod.ts";
+import { signal } from "https://deno.land/std@0.177.0/signal/mod.ts";
 
 // In global scope.
 declare global {

--- a/src/core/deno/config.ts
+++ b/src/core/deno/config.ts
@@ -4,7 +4,7 @@ import * as dbip from "./dbip.ts";
 import { services, stopAfter } from "../svc.js";
 import Log, { LogLevels } from "../log.js";
 import EnvManager from "../env.js";
-import { signal } from "https://deno.land/std@0.171.0/signal/mod.ts";
+import { signal } from "https://deno.land/std@0.178.0/signal/mod.ts";
 
 // In global scope.
 declare global {

--- a/src/server-deno.ts
+++ b/src/server-deno.ts
@@ -11,7 +11,7 @@
 import "./core/deno/config.ts";
 import { handleRequest } from "./core/doh.js";
 import { stopAfter, uptime } from "./core/svc.js";
-import { serve, serveTls } from "https://deno.land/std@0.178.0/http/server.ts";
+import { serve, serveTls } from "https://deno.land/std@0.177.0/http/server.ts";
 import * as system from "./system.js";
 import * as util from "./commons/util.js";
 import * as bufutil from "./commons/bufutil.js";
@@ -90,7 +90,7 @@ function systemUp() {
   // deno.land/manual@v1.31.0/runtime/http_server_apis
   async function startDoh() {
     if (terminateTls()) {
-      // deno.land/std@0.178.0/http/server.ts?s=serveTls
+      // deno.land/std@0.177.0/http/server.ts?s=serveTls
       serveTls(serveDoh, {
         ...dohConnOpts,
         ...tlsOpts,
@@ -98,7 +98,7 @@ function systemUp() {
         ...sigOpts,
       });
     } else {
-      // deno.land/std@0.178.0/http/server.ts?s=serve
+      // deno.land/std@0.177.0/http/server.ts?s=serve
       serve(serveDoh, { ...dohConnOpts, ...sigOpts });
     }
 

--- a/src/server-deno.ts
+++ b/src/server-deno.ts
@@ -11,7 +11,7 @@
 import "./core/deno/config.ts";
 import { handleRequest } from "./core/doh.js";
 import { stopAfter, uptime } from "./core/svc.js";
-import { serve, serveTls } from "https://deno.land/std@0.171.0/http/server.ts";
+import { serve, serveTls } from "https://deno.land/std@0.178.0/http/server.ts";
 import * as system from "./system.js";
 import * as util from "./commons/util.js";
 import * as bufutil from "./commons/bufutil.js";
@@ -79,7 +79,7 @@ function systemUp() {
     certFile: envutil.tlsCrtPath() as string,
     keyFile: envutil.tlsKeyPath() as string,
   };
-  // deno.land/manual@v1.18.0/runtime/http_server_apis_low_level
+  // deno.land/manual@v1.27.0/runtime/http_server_apis_low_level
   const httpOpts = {
     alpnProtocols: ["h2", "http/1.1"],
   };
@@ -87,10 +87,10 @@ function systemUp() {
   startDoh();
   startDotIfPossible();
 
-  // deno.land/manual@v1.29.1/runtime/http_server_apis
+  // deno.land/manual@v1.31.0/runtime/http_server_apis
   async function startDoh() {
     if (terminateTls()) {
-      // deno.land/std@0.170.0/http/server.ts?s=serveTls
+      // deno.land/std@0.178.0/http/server.ts?s=serveTls
       serveTls(serveDoh, {
         ...dohConnOpts,
         ...tlsOpts,
@@ -98,7 +98,7 @@ function systemUp() {
         ...sigOpts,
       });
     } else {
-      // deno.land/std@0.171.0/http/server.ts?s=serve
+      // deno.land/std@0.178.0/http/server.ts?s=serve
       serve(serveDoh, { ...dohConnOpts, ...sigOpts });
     }
 
@@ -117,7 +117,7 @@ function systemUp() {
 
     up("DoT (no blocklists)", dot, dotConnOpts);
 
-    // deno.land/manual@v1.11.3/runtime/http_server_apis#handling-connections
+    // deno.land/manual@v1.31.0/runtime/http_server_apis#handling-connections
     for await (const conn of dot) {
       log.d("DoT conn:", conn.remoteAddr);
 


### PR DESCRIPTION
Update to deno v1.31.0

the only thing worth mentioning with this update is that std/node is now apart of deno according to v1.178.0 so those can be removed from import map (I believe)