### PR TITLE
Add <> formatting to tls readme, fix settings.json error and update wrangler to support the latest compatibility date

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,5 @@
   ],
   "cSpell.enableFiletypes": [
     "env"
-  ],
+  ]
 }

--- a/test/data/tls/README.md
+++ b/test/data/tls/README.md
@@ -1,5 +1,5 @@
 Certificates in this directory expire in year 2121.
 
 Generated using instructions from this gist
-- https://gist.github.com/cecilemuller/9492b848eb8fe46d462abeb26656c4f8
-- https://archive.ph/1i2g8
+- <https://gist.github.com/cecilemuller/9492b848eb8fe46d462abeb26656c4f8>
+- <https://archive.ph/1i2g8>

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -5,7 +5,7 @@ const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 // archive.is/FDky9
 module.exports = {
   entry: "./src/server-workers.js",
-  target: ["webworker", "es2020"],
+  target: ["webworker", "es2022"],
   mode: "production",
   // enable devtool in development
   // devtool: 'eval-cheap-module-source-map',

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ workers_dev = true
 logpush = false
 # use node_compat or custom build
 # node_compat = true
-compatibility_date = "2023-03-07"
+compatibility_date = "2023-03-21"
 send_metrics = false
 minify = false
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ workers_dev = true
 logpush = false
 # use node_compat or custom build
 # node_compat = true
-compatibility_date = "2022-11-30"
+compatibility_date = "2023-03-14"
 send_metrics = false
 minify = false
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ workers_dev = true
 logpush = false
 # use node_compat or custom build
 # node_compat = true
-compatibility_date = "2023-03-14"
+compatibility_date = "2023-03-07"
 send_metrics = false
 minify = false
 


### PR DESCRIPTION
I know the .vscode file is not used in production but there is an error which this fixes. Validated by jsonlint.com / json validator.

Also adds <> formatting to the tls formatting just for good practices