### PR TITLE
Fix syntax error

### DIFF
--- a/src/core/doh.js
+++ b/src/core/doh.js
@@ -16,7 +16,7 @@ import IOState from "./io-state.js";
  * @param {FetchEvent} event
  * @returns {Promise<Response>}
  */
-export function handleRequest(event) {
+export async function handleRequest(event) {
   return proxyRequest(event);
 }
 


### PR DESCRIPTION
Fixes a syntax error since await will not be used correctly without async where I placed it. 