### PR TITLE
remove tcp checks from services and rely on custom health check exclusively

### DIFF
--- a/fly.machines.tls.toml
+++ b/fly.machines.tls.toml
@@ -40,12 +40,6 @@ protocol = "tcp"
   tls_options = { alpn = ["h2", "http/1.1"] }
   port = 8055
 
-  [[services.tcp_checks]]
-  grace_period = "5s"
-  interval = "10s"
-  restart_limit = 3
-  timeout = "2s"
-
 # DNS over TCP/TLS
 [[services]]
 internal_port = 10555
@@ -65,12 +59,6 @@ protocol = "tcp"
   # TODO: ProxyProto v2
   handlers = ["tls"]
   port = 10555
-
-  [[services.tcp_checks]]
-  grace_period = "5s"
-  interval = "10s"
-  restart_limit = 3
-  timeout = "2s"
 
 # community.fly.io/t/5490/3
 [checks]

--- a/fly.machines.toml
+++ b/fly.machines.toml
@@ -35,12 +35,6 @@ protocol = "tcp"
   [[services.ports]]
   port = 8080
 
-  [[services.tcp_checks]]
-  grace_period = "10s"
-  interval = "15s"
-  restart_limit = 3
-  timeout = "3s"
-
 # DNS over TCP/TLS
 [[services]]
 internal_port = 10000
@@ -56,12 +50,6 @@ protocol = "tcp"
 
   [[services.ports]]
   port = 10000
-
-  [[services.tcp_checks]]
-  grace_period = "10s"
-  interval = "15s"
-  restart_limit = 3
-  timeout = "3s"
 
 # community.fly.io/t/5490/3
 [checks]


### PR DESCRIPTION
In working through PR #147, we identified that the tcp checks from the fly.io platform were causing the machines to never scale to 0.  

In this PR, we remove TCP checks from both DoT and DoH services and rely on the custom health check exclusively.  By doing this, we reduce non-traffic being processed by the services and we eliminate a source of confusion if one health check gives us the thumbs up and a second does not.  That's a double edged sword though, if the current health check code doesn't fully check the health of the app, this PR may introduce instability.  I am not familiar enough with the code to know for certain if this is the case.