### PR TITLE
update undelegated domains

### DIFF
--- a/src/core/io-state.js
+++ b/src/core/io-state.js
@@ -305,7 +305,7 @@ export default class IOState {
   }
 
   // builds nxdomain response only for undelegated domains
-  // like .internal / .local .lan
+  // like .internal / .lan / .local (rfc6762) / .home.arpa (rfc8375)
   assignNxDomainResponse() {
     if (util.emptyObj(this.decodedDnsPacket.questions)) {
       this.log.e("decoded dns-packet missing question");

--- a/src/plugins/dns-op/prefilter.js
+++ b/src/plugins/dns-op/prefilter.js
@@ -11,7 +11,7 @@ import { log } from "../../core/log.js";
 import * as pres from "../plugin-response.js";
 
 // eslint-disable-next-line max-len
-// from: github.com/DNSCrypt/dnscrypt-proxy/blob/10ded3d9f/dnscrypt-proxy/plugin_block_undelegated.go
+// from: https://github.com/DNSCrypt/dnscrypt-proxy/blob/987ae216e30c40152ec8d820fa93e7c75240e579/dnscrypt-proxy/plugin_block_undelegated.go
 const undelegated = new Set([
   // eslint-disable-next-line max-len
   "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
@@ -128,9 +128,11 @@ const undelegated = new Set([
   "envoy",
   "example",
   "f.f.ip6.arpa",
+  "fritz.box",
   "grp",
   "gw==",
   "home",
+  "home.arpa",
   "hub",
   "internal",
   "intra",
@@ -143,6 +145,7 @@ const undelegated = new Set([
   "localdomain",
   "localhost",
   "localnet",
+  "mail",
   "modem",
   "mynet",
   "myrouter",

--- a/src/plugins/dns-op/prefilter.js
+++ b/src/plugins/dns-op/prefilter.js
@@ -11,7 +11,7 @@ import { log } from "../../core/log.js";
 import * as pres from "../plugin-response.js";
 
 // eslint-disable-next-line max-len
-// from: github.com/DNSCrypt/dnscrypt-proxy/blob/10ded3d9f/dnscrypt-proxy/plugin_block_undelegated.go
+// from: https://github.com/DNSCrypt/dnscrypt-proxy/blob/140587c79df3c1edb7fe11fa2f9c135e122e584b/dnscrypt-proxy/plugin_block_undelegated.go
 const undelegated = new Set([
   // eslint-disable-next-line max-len
   "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa",
@@ -128,9 +128,11 @@ const undelegated = new Set([
   "envoy",
   "example",
   "f.f.ip6.arpa",
+  "fritz.box",
   "grp",
   "gw==",
   "home",
+  "home.arpa",
   "hub",
   "internal",
   "intra",
@@ -143,6 +145,7 @@ const undelegated = new Set([
   "localdomain",
   "localhost",
   "localnet",
+  "mail",
   "modem",
   "mynet",
   "myrouter",


### PR DESCRIPTION
list updated from official dnscrypt-proxy source (https://github.com/DNSCrypt/dnscrypt-proxy/blob/140587c79df3c1edb7fe11fa2f9c135e122e584b/dnscrypt-proxy/plugin_block_undelegated.go#L8)

valuable because some people already moved to the officially recommended domain for local dns use `home.arpa` or are forced to use `fritz.box` (hard coded by the most common german router oem avm in their fritz box models)

i didn't find a CONTRIBUTING.md file so excuse me if i did something wrong and let me know if i should adapt anything